### PR TITLE
Add `pre-commit` to check and format the codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+repos:
+  # Generic hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+
+  # https://black.readthedocs.io/en/stable/integrations/source_version_control.html
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+
+  # https://docs.astral.sh/ruff/integrations/#pre-commit
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.12.3
+    hooks:
+      - id: ruff-check

--- a/gi_notifier/config.py
+++ b/gi_notifier/config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 BOTTOKEN = ""
 TIMEZONE = "Asia/Kolkata"
 HOURLIST = [iter for iter in range(24) if iter % 4 == 0]
-DATA_FILE = Path("/tmp/gi-notifier/bot_user_data.json")  #noqa: S108
+DATA_FILE = Path("/tmp/gi-notifier/bot_user_data.json")  # noqa: S108
 
 logrconf = {
     "version": 1,

--- a/gi_notifier/data/book/admonition.py
+++ b/gi_notifier/data/book/admonition.py
@@ -6,8 +6,14 @@ class Admonition(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Admonition Books", "https://genshin-impact.fandom.com/wiki/Admonition_Book"),
-            source=Source("Steeple of Ignorance", "https://genshin-impact.fandom.com/wiki/Steeple_of_Ignorance")
+            item=Item(
+                "Admonition Books",
+                "https://genshin-impact.fandom.com/wiki/Admonition_Book",
+            ),
+            source=Source(
+                "Steeple of Ignorance",
+                "https://genshin-impact.fandom.com/wiki/Steeple_of_Ignorance",
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/ballad.py
+++ b/gi_notifier/data/book/ballad.py
@@ -6,8 +6,12 @@ class Ballad(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Ballad Books", "https://genshin-impact.fandom.com/wiki/Ballad_Book"),
-            source=Source("Forsaken Rift", "https://genshin-impact.fandom.com/wiki/Forsaken_Rift")
+            item=Item(
+                "Ballad Books", "https://genshin-impact.fandom.com/wiki/Ballad_Book"
+            ),
+            source=Source(
+                "Forsaken Rift", "https://genshin-impact.fandom.com/wiki/Forsaken_Rift"
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/conflict.py
+++ b/gi_notifier/data/book/conflict.py
@@ -6,8 +6,12 @@ class Conflict(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Conflict Books", "https://genshin-impact.fandom.com/wiki/Conflict_Book"),
-            source=Source("Blazing Ruins", "https://genshin-impact.fandom.com/wiki/Blazing_Ruins")
+            item=Item(
+                "Conflict Books", "https://genshin-impact.fandom.com/wiki/Conflict_Book"
+            ),
+            source=Source(
+                "Blazing Ruins", "https://genshin-impact.fandom.com/wiki/Blazing_Ruins"
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/contention.py
+++ b/gi_notifier/data/book/contention.py
@@ -6,8 +6,13 @@ class Contention(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Contention Books", "https://genshin-impact.fandom.com/wiki/Contention_Book"),
-            source=Source("Blazing Ruins", "https://genshin-impact.fandom.com/wiki/Blazing_Ruins")
+            item=Item(
+                "Contention Books",
+                "https://genshin-impact.fandom.com/wiki/Contention_Book",
+            ),
+            source=Source(
+                "Blazing Ruins", "https://genshin-impact.fandom.com/wiki/Blazing_Ruins"
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/diligence.py
+++ b/gi_notifier/data/book/diligence.py
@@ -6,8 +6,14 @@ class Diligence(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Diligence Books", "https://genshin-impact.fandom.com/wiki/Diligence_Book"),
-            source=Source("Taishan Mansion", "https://genshin-impact.fandom.com/wiki/Taishan_Mansion")
+            item=Item(
+                "Diligence Books",
+                "https://genshin-impact.fandom.com/wiki/Diligence_Book",
+            ),
+            source=Source(
+                "Taishan Mansion",
+                "https://genshin-impact.fandom.com/wiki/Taishan_Mansion",
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/elegance.py
+++ b/gi_notifier/data/book/elegance.py
@@ -6,8 +6,12 @@ class Elegance(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Elegance Books", "https://genshin-impact.fandom.com/wiki/Elegance_Book"),
-            source=Source("Violet Court", "https://genshin-impact.fandom.com/wiki/Violet_Court")
+            item=Item(
+                "Elegance Books", "https://genshin-impact.fandom.com/wiki/Elegance_Book"
+            ),
+            source=Source(
+                "Violet Court", "https://genshin-impact.fandom.com/wiki/Violet_Court"
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/equity.py
+++ b/gi_notifier/data/book/equity.py
@@ -6,8 +6,13 @@ class Equity(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Equity Books", "https://genshin-impact.fandom.com/wiki/Equity_Book"),
-            source=Source("Pale Forgotten Glory", "https://genshin-impact.fandom.com/wiki/Pale_Forgotten_Glory")
+            item=Item(
+                "Equity Books", "https://genshin-impact.fandom.com/wiki/Equity_Book"
+            ),
+            source=Source(
+                "Pale Forgotten Glory",
+                "https://genshin-impact.fandom.com/wiki/Pale_Forgotten_Glory",
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/freedom.py
+++ b/gi_notifier/data/book/freedom.py
@@ -6,8 +6,12 @@ class Freedom(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Freedom Books", "https://genshin-impact.fandom.com/wiki/Freedom_Book"),
-            source=Source("Forsaken Rift", "https://genshin-impact.fandom.com/wiki/Forsaken_Rift")
+            item=Item(
+                "Freedom Books", "https://genshin-impact.fandom.com/wiki/Freedom_Book"
+            ),
+            source=Source(
+                "Forsaken Rift", "https://genshin-impact.fandom.com/wiki/Forsaken_Rift"
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/gold.py
+++ b/gi_notifier/data/book/gold.py
@@ -7,7 +7,10 @@ class Gold(MaterialGroupBase):
     def drop(self) -> Drop:
         return Drop(
             item=Item("Gold Books", "https://genshin-impact.fandom.com/wiki/Gold_Book"),
-            source=Source("Taishan Mansion", "https://genshin-impact.fandom.com/wiki/Taishan_Mansion")
+            source=Source(
+                "Taishan Mansion",
+                "https://genshin-impact.fandom.com/wiki/Taishan_Mansion",
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/ingenuity.py
+++ b/gi_notifier/data/book/ingenuity.py
@@ -6,8 +6,14 @@ class Ingenuity(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Ingenuity Books", "https://genshin-impact.fandom.com/wiki/Ingenuity_Book"),
-            source=Source("Steeple of Ignorance", "https://genshin-impact.fandom.com/wiki/Steeple_of_Ignorance")
+            item=Item(
+                "Ingenuity Books",
+                "https://genshin-impact.fandom.com/wiki/Ingenuity_Book",
+            ),
+            source=Source(
+                "Steeple of Ignorance",
+                "https://genshin-impact.fandom.com/wiki/Steeple_of_Ignorance",
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/justice.py
+++ b/gi_notifier/data/book/justice.py
@@ -6,8 +6,13 @@ class Justice(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Justice Books", "https://genshin-impact.fandom.com/wiki/Justice_Book"),
-            source=Source("Pale Forgotten Glory", "https://genshin-impact.fandom.com/wiki/Pale_Forgotten_Glory")
+            item=Item(
+                "Justice Books", "https://genshin-impact.fandom.com/wiki/Justice_Book"
+            ),
+            source=Source(
+                "Pale Forgotten Glory",
+                "https://genshin-impact.fandom.com/wiki/Pale_Forgotten_Glory",
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/kindling.py
+++ b/gi_notifier/data/book/kindling.py
@@ -6,8 +6,12 @@ class Kindling(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Kindling Books", "https://genshin-impact.fandom.com/wiki/Kindling_Book"),
-            source=Source("Blazing Ruins", "https://genshin-impact.fandom.com/wiki/Blazing_Ruins")
+            item=Item(
+                "Kindling Books", "https://genshin-impact.fandom.com/wiki/Kindling_Book"
+            ),
+            source=Source(
+                "Blazing Ruins", "https://genshin-impact.fandom.com/wiki/Blazing_Ruins"
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/light.py
+++ b/gi_notifier/data/book/light.py
@@ -6,8 +6,12 @@ class Light(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Light Books", "https://genshin-impact.fandom.com/wiki/Light_Book"),
-            source=Source("Violet Court", "https://genshin-impact.fandom.com/wiki/Violet_Court")
+            item=Item(
+                "Light Books", "https://genshin-impact.fandom.com/wiki/Light_Book"
+            ),
+            source=Source(
+                "Violet Court", "https://genshin-impact.fandom.com/wiki/Violet_Court"
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/order.py
+++ b/gi_notifier/data/book/order.py
@@ -6,8 +6,13 @@ class Order(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Order Books", "https://genshin-impact.fandom.com/wiki/Order_Book"),
-            source=Source("Pale Forgotten Glory", "https://genshin-impact.fandom.com/wiki/Pale_Forgotten_Glory")
+            item=Item(
+                "Order Books", "https://genshin-impact.fandom.com/wiki/Order_Book"
+            ),
+            source=Source(
+                "Pale Forgotten Glory",
+                "https://genshin-impact.fandom.com/wiki/Pale_Forgotten_Glory",
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/praxis.py
+++ b/gi_notifier/data/book/praxis.py
@@ -6,8 +6,13 @@ class Praxis(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Praxis Books", "https://genshin-impact.fandom.com/wiki/Praxis_Book"),
-            source=Source("Steeple of Ignorance", "https://genshin-impact.fandom.com/wiki/Steeple_of_Ignorance")
+            item=Item(
+                "Praxis Books", "https://genshin-impact.fandom.com/wiki/Praxis_Book"
+            ),
+            source=Source(
+                "Steeple of Ignorance",
+                "https://genshin-impact.fandom.com/wiki/Steeple_of_Ignorance",
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/prosperity.py
+++ b/gi_notifier/data/book/prosperity.py
@@ -6,8 +6,14 @@ class Prosperity(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Prosperity Books", "https://genshin-impact.fandom.com/wiki/Prosperity_Book"),
-            source=Source("Taishan Mansion", "https://genshin-impact.fandom.com/wiki/Taishan_Mansion")
+            item=Item(
+                "Prosperity Books",
+                "https://genshin-impact.fandom.com/wiki/Prosperity_Book",
+            ),
+            source=Source(
+                "Taishan Mansion",
+                "https://genshin-impact.fandom.com/wiki/Taishan_Mansion",
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/resistance.py
+++ b/gi_notifier/data/book/resistance.py
@@ -6,8 +6,13 @@ class Resistance(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Resistance Books", "https://genshin-impact.fandom.com/wiki/Resistance_Book"),
-            source=Source("Forsaken Rift", "https://genshin-impact.fandom.com/wiki/Forsaken_Rift")
+            item=Item(
+                "Resistance Books",
+                "https://genshin-impact.fandom.com/wiki/Resistance_Book",
+            ),
+            source=Source(
+                "Forsaken Rift", "https://genshin-impact.fandom.com/wiki/Forsaken_Rift"
+            ),
         )
 
     @property

--- a/gi_notifier/data/book/transience.py
+++ b/gi_notifier/data/book/transience.py
@@ -6,8 +6,13 @@ class Transience(MaterialGroupBase):
     @property
     def drop(self) -> Drop:
         return Drop(
-            item=Item("Transience Books", "https://genshin-impact.fandom.com/wiki/Transience_Book"),
-            source=Source("Violet Court", "https://genshin-impact.fandom.com/wiki/Violet_Court")
+            item=Item(
+                "Transience Books",
+                "https://genshin-impact.fandom.com/wiki/Transience_Book",
+            ),
+            source=Source(
+                "Violet Court", "https://genshin-impact.fandom.com/wiki/Violet_Court"
+            ),
         )
 
     @property

--- a/gi_notifier/data/char/albedo.py
+++ b/gi_notifier/data/char/albedo.py
@@ -17,13 +17,25 @@ class Albedo(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Basalt Pillar", f"https://genshin-impact.fandom.com/wiki/{quote("Basalt_Pillar")}"),
-            source = Source("Geo Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Geo_Hypostasis")}")
+            item=Item(
+                "Basalt Pillar",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Basalt_Pillar")}",
+            ),
+            source=Source(
+                "Geo Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Geo_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Tusk of Monoceros Caeli", f"https://genshin-impact.fandom.com/wiki/{quote("Tusk_of_Monoceros_Caeli")}"),
-            source = Source("Enter the Golden House", f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}")
+            item=Item(
+                "Tusk of Monoceros Caeli",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tusk_of_Monoceros_Caeli")}",
+            ),
+            source=Source(
+                "Enter the Golden House",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}",
+            ),
         )

--- a/gi_notifier/data/char/alhaitham.py
+++ b/gi_notifier/data/char/alhaitham.py
@@ -17,13 +17,25 @@ class Alhaitham(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Pseudo-Stamens", f"https://genshin-impact.fandom.com/wiki/{quote("Pseudo-Stamens")}"),
-            source = Source("Setekh Wenut", f"https://genshin-impact.fandom.com/wiki/{quote("Setekh_Wenut")}")
+            item=Item(
+                "Pseudo-Stamens",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Pseudo-Stamens")}",
+            ),
+            source=Source(
+                "Setekh Wenut",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Setekh_Wenut")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Mirror of Mushin", f"https://genshin-impact.fandom.com/wiki/{quote("Mirror_of_Mushin")}"),
-            source = Source("Joururi Workshop", f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}")
+            item=Item(
+                "Mirror of Mushin",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Mirror_of_Mushin")}",
+            ),
+            source=Source(
+                "Joururi Workshop",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}",
+            ),
         )

--- a/gi_notifier/data/char/aloy.py
+++ b/gi_notifier/data/char/aloy.py
@@ -17,13 +17,25 @@ class Aloy(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Crystalline Bloom", f"https://genshin-impact.fandom.com/wiki/{quote("Crystalline_Bloom")}"),
-            source = Source("Cryo Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Hypostasis")}")
+            item=Item(
+                "Crystalline Bloom",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Crystalline_Bloom")}",
+            ),
+            source=Source(
+                "Cryo Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Molten Moment", f"https://genshin-impact.fandom.com/wiki/{quote("Molten_Moment")}"),
-            source = Source("Narukami Island: Tenshukaku", f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}")
+            item=Item(
+                "Molten Moment",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Molten_Moment")}",
+            ),
+            source=Source(
+                "Narukami Island: Tenshukaku",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}",
+            ),
         )

--- a/gi_notifier/data/char/amber.py
+++ b/gi_notifier/data/char/amber.py
@@ -17,13 +17,25 @@ class Amber(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Everflame Seed", f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}"),
-            source = Source("Pyro Regisvines", f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvines")}")
+            item=Item(
+                "Everflame Seed",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}",
+            ),
+            source=Source(
+                "Pyro Regisvines",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvines")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dvalin's Sigh", f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Sigh")}"),
-            source = Source("Confront Stormterror", f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}")
+            item=Item(
+                "Dvalin's Sigh",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Sigh")}",
+            ),
+            source=Source(
+                "Confront Stormterror",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}",
+            ),
         )

--- a/gi_notifier/data/char/arataki_itto.py
+++ b/gi_notifier/data/char/arataki_itto.py
@@ -17,13 +17,25 @@ class AratakiItto(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Riftborn Regalia", f"https://genshin-impact.fandom.com/wiki/{quote("Riftborn_Regalia")}"),
-            source = Source("Golden Wolflord", f"https://genshin-impact.fandom.com/wiki/{quote("Golden_Wolflord")}")
+            item=Item(
+                "Riftborn Regalia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Riftborn_Regalia")}",
+            ),
+            source=Source(
+                "Golden Wolflord",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Golden_Wolflord")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Ashen Heart", f"https://genshin-impact.fandom.com/wiki/{quote("Ashen_Heart")}"),
-            source = Source("Narukami Island: Tenshukaku", f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}")
+            item=Item(
+                "Ashen Heart",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ashen_Heart")}",
+            ),
+            source=Source(
+                "Narukami Island: Tenshukaku",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}",
+            ),
         )

--- a/gi_notifier/data/char/arlecchino.py
+++ b/gi_notifier/data/char/arlecchino.py
@@ -17,13 +17,25 @@ class Arlecchino(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Fragment of a Golden Melody", f"https://genshin-impact.fandom.com/wiki/{quote("Fragment_of_a_Golden_Melody")}"),
-            source = Source("Statue of Marble and Brass", f"https://genshin-impact.fandom.com/wiki/{quote("\"Statue of Marble and Brass\"")}")
+            item=Item(
+                "Fragment of a Golden Melody",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Fragment_of_a_Golden_Melody")}",
+            ),
+            source=Source(
+                "Statue of Marble and Brass",
+                f"https://genshin-impact.fandom.com/wiki/{quote("\"Statue of Marble and Brass\"")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Fading Candle", f"https://genshin-impact.fandom.com/wiki/{quote("Fading_Candle")}"),
-            source = Source("The Knave", f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}")
+            item=Item(
+                "Fading Candle",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Fading_Candle")}",
+            ),
+            source=Source(
+                "The Knave",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}",
+            ),
         )

--- a/gi_notifier/data/char/baizhu.py
+++ b/gi_notifier/data/char/baizhu.py
@@ -17,13 +17,25 @@ class Baizhu(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Evergloom Ring", f"https://genshin-impact.fandom.com/wiki/{quote("Evergloom_Ring")}"),
-            source = Source("Iniquitous Baptist", f"https://genshin-impact.fandom.com/wiki/{quote("Iniquitous_Baptist")}")
+            item=Item(
+                "Evergloom Ring",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Evergloom_Ring")}",
+            ),
+            source=Source(
+                "Iniquitous Baptist",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Iniquitous_Baptist")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Worldspan Fern", f"https://genshin-impact.fandom.com/wiki/{quote("Worldspan_Fern")}"),
-            source = Source("The Realm of Beginnings", f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}")
+            item=Item(
+                "Worldspan Fern",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Worldspan_Fern")}",
+            ),
+            source=Source(
+                "The Realm of Beginnings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}",
+            ),
         )

--- a/gi_notifier/data/char/barbara.py
+++ b/gi_notifier/data/char/barbara.py
@@ -17,13 +17,25 @@ class Barbara(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Cleansing Heart", f"https://genshin-impact.fandom.com/wiki/{quote("Cleansing_Heart")}"),
-            source = Source("Rhodeia of Loch", f"https://genshin-impact.fandom.com/wiki/{quote("Rhodeia_of_Loch")}")
+            item=Item(
+                "Cleansing Heart",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cleansing_Heart")}",
+            ),
+            source=Source(
+                "Rhodeia of Loch",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Rhodeia_of_Loch")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Ring of Boreas", f"https://genshin-impact.fandom.com/wiki/{quote("Ring_of_Boreas")}"),
-            source = Source("Wolf of the North Challenge", f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}")
+            item=Item(
+                "Ring of Boreas",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ring_of_Boreas")}",
+            ),
+            source=Source(
+                "Wolf of the North Challenge",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}",
+            ),
         )

--- a/gi_notifier/data/char/beidou.py
+++ b/gi_notifier/data/char/beidou.py
@@ -17,13 +17,25 @@ class Beidou(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Lightning Prism", f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}"),
-            source = Source("Electro Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}")
+            item=Item(
+                "Lightning Prism",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}",
+            ),
+            source=Source(
+                "Electro Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dvalin's Sigh", f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Sigh")}"),
-            source = Source("Confront Stormterror", f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}")
+            item=Item(
+                "Dvalin's Sigh",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Sigh")}",
+            ),
+            source=Source(
+                "Confront Stormterror",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}",
+            ),
         )

--- a/gi_notifier/data/char/bennett.py
+++ b/gi_notifier/data/char/bennett.py
@@ -17,13 +17,25 @@ class Bennett(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Everflame Seed", f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}"),
-            source = Source("Pyro Regisvines", f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvines")}")
+            item=Item(
+                "Everflame Seed",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}",
+            ),
+            source=Source(
+                "Pyro Regisvines",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvines")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dvalin's Plume", f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Plume")}"),
-            source = Source("Confront Stormterror", f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}")
+            item=Item(
+                "Dvalin's Plume",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Plume")}",
+            ),
+            source=Source(
+                "Confront Stormterror",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}",
+            ),
         )

--- a/gi_notifier/data/char/candace.py
+++ b/gi_notifier/data/char/candace.py
@@ -17,13 +17,25 @@ class Candace(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Light Guiding Tetrahedron", f"https://genshin-impact.fandom.com/wiki/{quote("Light_Guiding_Tetrahedron")}"),
-            source = Source("Algorithm of Semi-Intransient Matrix of Overseer Network", f"https://genshin-impact.fandom.com/wiki/{quote("Algorithm_of_Semi-Intransient_Matrix_of_Overseer_Network")}")
+            item=Item(
+                "Light Guiding Tetrahedron",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Light_Guiding_Tetrahedron")}",
+            ),
+            source=Source(
+                "Algorithm of Semi-Intransient Matrix of Overseer Network",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Algorithm_of_Semi-Intransient_Matrix_of_Overseer_Network")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Tears of the Calamitous God", f"https://genshin-impact.fandom.com/wiki/{quote("Tears_of_the_Calamitous_God")}"),
-            source = Source("End of the Oneiric Euthymia", f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}")
+            item=Item(
+                "Tears of the Calamitous God",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tears_of_the_Calamitous_God")}",
+            ),
+            source=Source(
+                "End of the Oneiric Euthymia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}",
+            ),
         )

--- a/gi_notifier/data/char/charlotte.py
+++ b/gi_notifier/data/char/charlotte.py
@@ -17,13 +17,25 @@ class Charlotte(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item('"Tourbillon Device"', f"https://genshin-impact.fandom.com/wiki/{quote("\"Tourbillon Device\"")}"),
-            source = Source("Experimental Field Generator", f"https://genshin-impact.fandom.com/wiki/{quote("Experimental_Field_Generator")}")
+            item=Item(
+                '"Tourbillon Device"',
+                f"https://genshin-impact.fandom.com/wiki/{quote("\"Tourbillon Device\"")}",
+            ),
+            source=Source(
+                "Experimental Field Generator",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Experimental_Field_Generator")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Lightless Silk String", f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Silk_String")}"),
-            source = Source("All-Devouring Narwhal", f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}")
+            item=Item(
+                "Lightless Silk String",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Silk_String")}",
+            ),
+            source=Source(
+                "All-Devouring Narwhal",
+                f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}",
+            ),
         )

--- a/gi_notifier/data/char/chasca.py
+++ b/gi_notifier/data/char/chasca.py
@@ -17,14 +17,25 @@ class Chasca(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Ensnaring Gaze", f"https://genshin-impact.fandom.com/wiki/{quote("Ensnaring_Gaze")}"),
-            source = Source("Tenebrous Papilla", f"https://genshin-impact.fandom.com/wiki/{quote("Tenebrous_Papilla")}")
+            item=Item(
+                "Ensnaring Gaze",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ensnaring_Gaze")}",
+            ),
+            source=Source(
+                "Tenebrous Papilla",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tenebrous_Papilla")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Silken Feather", f"https://genshin-impact.fandom.com/wiki/{quote("Silken_Feather")}"),
-            source = Source("The Knave", f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}")
+            item=Item(
+                "Silken Feather",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Silken_Feather")}",
+            ),
+            source=Source(
+                "The Knave",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}",
+            ),
         )
-

--- a/gi_notifier/data/char/chevreuse.py
+++ b/gi_notifier/data/char/chevreuse.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+
 from ...models.base import CharacterBase
 from ...models.models import Drop, Item, Source
 from ..book.order import Order
@@ -16,13 +17,25 @@ class Chevreuse(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Fontemer Unihorn", f"https://genshin-impact.fandom.com/wiki/{quote("Fontemer_Unihorn")}"),
-            source = Source("Millennial Pearl Seahorse", f"https://genshin-impact.fandom.com/wiki/{quote("Millennial_Pearl_Seahorse")}")
+            item=Item(
+                "Fontemer Unihorn",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Fontemer_Unihorn")}",
+            ),
+            source=Source(
+                "Millennial Pearl Seahorse",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Millennial_Pearl_Seahorse")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Lightless Eye of the Maelstrom", f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Eye_of_the_Maelstrom")}"),
-            source = Source("All-Devouring Narwhal", f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}")
+            item=Item(
+                "Lightless Eye of the Maelstrom",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Eye_of_the_Maelstrom")}",
+            ),
+            source=Source(
+                "All-Devouring Narwhal",
+                f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}",
+            ),
         )

--- a/gi_notifier/data/char/chiori.py
+++ b/gi_notifier/data/char/chiori.py
@@ -17,13 +17,25 @@ class Chiori(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Artificed Spare Clockwork Component — Coppelia", f"https://genshin-impact.fandom.com/wiki/{quote("Artificed_Spare_Clockwork_Component_—_Coppelia")}"),
-            source = Source("Icewind Suite: Dirge of Coppelia", f"https://genshin-impact.fandom.com/wiki/{quote("Icewind_Suite:_Dirge_of_Coppelia")}")
+            item=Item(
+                "Artificed Spare Clockwork Component — Coppelia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Artificed_Spare_Clockwork_Component_—_Coppelia")}",
+            ),
+            source=Source(
+                "Icewind Suite: Dirge of Coppelia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Icewind_Suite:_Dirge_of_Coppelia")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Lightless Silk String", f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Silk_String")}"),
-            source = Source("All-Devouring Narwhal", f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}")
+            item=Item(
+                "Lightless Silk String",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Silk_String")}",
+            ),
+            source=Source(
+                "All-Devouring Narwhal",
+                f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}",
+            ),
         )

--- a/gi_notifier/data/char/chongyun.py
+++ b/gi_notifier/data/char/chongyun.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+
 from ...models.base import CharacterBase
 from ...models.models import Drop, Item, Source
 from ..book.diligence import Diligence
@@ -16,13 +17,25 @@ class Chongyun(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Hoarfrost Core", f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}"),
-            source = Source("Cryo Regisvine", f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}")
+            item=Item(
+                "Hoarfrost Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}",
+            ),
+            source=Source(
+                "Cryo Regisvine",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dvalin's Sigh", f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Sigh")}"),
-            source = Source("Confront Stormterror", f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}")
+            item=Item(
+                "Dvalin's Sigh",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Sigh")}",
+            ),
+            source=Source(
+                "Confront Stormterror",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}",
+            ),
         )

--- a/gi_notifier/data/char/citlali.py
+++ b/gi_notifier/data/char/citlali.py
@@ -17,13 +17,25 @@ class Citlali(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Talisman of the Enigmatic Land", f"https://genshin-impact.fandom.com/wiki/{quote("Talisman_of_the_Enigmatic_Land")}"),
-            source = Source("Wayward Hermetic Spiritspeaker", f"https://genshin-impact.fandom.com/wiki/{quote("Wayward_Hermetic_Spiritspeaker")}")
+            item=Item(
+                "Talisman of the Enigmatic Land",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Talisman_of_the_Enigmatic_Land")}",
+            ),
+            source=Source(
+                "Wayward Hermetic Spiritspeaker",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Wayward_Hermetic_Spiritspeaker")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Denial and Judgment", f"https://genshin-impact.fandom.com/wiki/{quote("Denial_and_Judgment")}"),
-            source = Source("The Knave", f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}")
+            item=Item(
+                "Denial and Judgment",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Denial_and_Judgment")}",
+            ),
+            source=Source(
+                "The Knave",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}",
+            ),
         )

--- a/gi_notifier/data/char/clorinde.py
+++ b/gi_notifier/data/char/clorinde.py
@@ -17,13 +17,25 @@ class Clorinde(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Fontemer Unihorn", f"https://genshin-impact.fandom.com/wiki/{quote("Fontemer_Unihorn")}"),
-            source = Source("Millennial Pearl Seahorse", f"https://genshin-impact.fandom.com/wiki/{quote("Millennial_Pearl_Seahorse")}")
+            item=Item(
+                "Fontemer Unihorn",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Fontemer_Unihorn")}",
+            ),
+            source=Source(
+                "Millennial Pearl Seahorse",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Millennial_Pearl_Seahorse")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Everamber", f"https://genshin-impact.fandom.com/wiki/{quote("Everamber")}"),
-            source = Source("The Realm of Beginnings", f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}")
+            item=Item(
+                "Everamber",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Everamber")}",
+            ),
+            source=Source(
+                "The Realm of Beginnings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}",
+            ),
         )

--- a/gi_notifier/data/char/collei.py
+++ b/gi_notifier/data/char/collei.py
@@ -17,13 +17,25 @@ class Collei(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Majestic Hooked Beak", f"https://genshin-impact.fandom.com/wiki/{quote("Majestic_Hooked_Beak")}"),
-            source = Source("Jadeplume Terrorshroom", f"https://genshin-impact.fandom.com/wiki/{quote("Jadeplume_Terrorshroom")}")
+            item=Item(
+                "Majestic Hooked Beak",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Majestic_Hooked_Beak")}",
+            ),
+            source=Source(
+                "Jadeplume Terrorshroom",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Jadeplume_Terrorshroom")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Tears of the Calamitous God", f"https://genshin-impact.fandom.com/wiki/{quote("Tears_of_the_Calamitous_God")}"),
-            source = Source("End of the Oneiric Euthymia", f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}")
+            item=Item(
+                "Tears of the Calamitous God",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tears_of_the_Calamitous_God")}",
+            ),
+            source=Source(
+                "End of the Oneiric Euthymia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}",
+            ),
         )

--- a/gi_notifier/data/char/cyno.py
+++ b/gi_notifier/data/char/cyno.py
@@ -17,13 +17,25 @@ class Cyno(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Thunderclap Fruitcore", f"https://genshin-impact.fandom.com/wiki/{quote("Thunderclap_Fruitcore")}"),
-            source = Source("Electro Regisvines", f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Regisvines")}")
+            item=Item(
+                "Thunderclap Fruitcore",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Thunderclap_Fruitcore")}",
+            ),
+            source=Source(
+                "Electro Regisvines",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Regisvines")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Mudra of the Malefic General", f"https://genshin-impact.fandom.com/wiki/{quote("Mudra_of_the_Malefic_General")}"),
-            source = Source("End of the Oneiric Euthymia", f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}")
+            item=Item(
+                "Mudra of the Malefic General",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Mudra_of_the_Malefic_General")}",
+            ),
+            source=Source(
+                "End of the Oneiric Euthymia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}",
+            ),
         )

--- a/gi_notifier/data/char/dehya.py
+++ b/gi_notifier/data/char/dehya.py
@@ -17,13 +17,25 @@ class Dehya(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Light Guiding Tetrahedron", f"https://genshin-impact.fandom.com/wiki/{quote("Light_Guiding_Tetrahedron")}"),
-            source = Source("Algorithm of Semi-Intransient Matrix of Overseer Network", f"https://genshin-impact.fandom.com/wiki/{quote("Algorithm_of_Semi-Intransient_Matrix_of_Overseer_Network")}")
+            item=Item(
+                "Light Guiding Tetrahedron",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Light_Guiding_Tetrahedron")}",
+            ),
+            source=Source(
+                "Algorithm of Semi-Intransient Matrix of Overseer Network",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Algorithm_of_Semi-Intransient_Matrix_of_Overseer_Network")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Puppet Strings", f"https://genshin-impact.fandom.com/wiki/{quote("Puppet_Strings")}"),
-            source = Source("Joururi Workshop", f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}")
+            item=Item(
+                "Puppet Strings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Puppet_Strings")}",
+            ),
+            source=Source(
+                "Joururi Workshop",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}",
+            ),
         )

--- a/gi_notifier/data/char/diluc.py
+++ b/gi_notifier/data/char/diluc.py
@@ -17,13 +17,25 @@ class Diluc(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Everflame Seed", f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}"),
-            source = Source("Pyro Regisvines", f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvines")}")
+            item=Item(
+                "Everflame Seed",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}",
+            ),
+            source=Source(
+                "Pyro Regisvines",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvines")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dvalin's Plume", f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Plume")}"),
-            source = Source("Confront Stormterror", f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}")
+            item=Item(
+                "Dvalin's Plume",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Plume")}",
+            ),
+            source=Source(
+                "Confront Stormterror",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}",
+            ),
         )

--- a/gi_notifier/data/char/diona.py
+++ b/gi_notifier/data/char/diona.py
@@ -17,13 +17,25 @@ class Diona(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Hoarfrost Core", f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}"),
-            source = Source("Cryo Regisvine", f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}")
+            item=Item(
+                "Hoarfrost Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}",
+            ),
+            source=Source(
+                "Cryo Regisvine",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Shard of a Foul Legacy", f"https://genshin-impact.fandom.com/wiki/{quote("Shard_of_a_Foul_Legacy")}"),
-            source = Source("Enter the Golden House", f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}")
+            item=Item(
+                "Shard of a Foul Legacy",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Shard_of_a_Foul_Legacy")}",
+            ),
+            source=Source(
+                "Enter the Golden House",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}",
+            ),
         )

--- a/gi_notifier/data/char/dori.py
+++ b/gi_notifier/data/char/dori.py
@@ -17,13 +17,25 @@ class Dori(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Thunderclap Fruitcore", f"https://genshin-impact.fandom.com/wiki/{quote("Thunderclap_Fruitcore")}"),
-            source = Source("Electro Regisvines", f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Regisvines")}")
+            item=Item(
+                "Thunderclap Fruitcore",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Thunderclap_Fruitcore")}",
+            ),
+            source=Source(
+                "Electro Regisvines",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Regisvines")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Bloodjade Branch", f"https://genshin-impact.fandom.com/wiki/{quote("Bloodjade_Branch")}"),
-            source = Source("Beneath the Dragon-Queller", f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}")
+            item=Item(
+                "Bloodjade Branch",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Bloodjade_Branch")}",
+            ),
+            source=Source(
+                "Beneath the Dragon-Queller",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}",
+            ),
         )

--- a/gi_notifier/data/char/emilie.py
+++ b/gi_notifier/data/char/emilie.py
@@ -17,13 +17,25 @@ class Emilie(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Fragment of a Golden Melody", f"https://genshin-impact.fandom.com/wiki/{quote("Fragment_of_a_Golden_Melody")}"),
-            source = Source("Statue of Marble and Brass", f"https://genshin-impact.fandom.com/wiki/{quote("\"Statue_of_Marble_and_Brass\"")}")
+            item=Item(
+                "Fragment of a Golden Melody",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Fragment_of_a_Golden_Melody")}",
+            ),
+            source=Source(
+                "Statue of Marble and Brass",
+                f"https://genshin-impact.fandom.com/wiki/{quote("\"Statue_of_Marble_and_Brass\"")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Silken Feather", f"https://genshin-impact.fandom.com/wiki/{quote("Silken_Feather")}"),
-            source = Source("The Knave", f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}")
+            item=Item(
+                "Silken Feather",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Silken_Feather")}",
+            ),
+            source=Source(
+                "The Knave",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}",
+            ),
         )

--- a/gi_notifier/data/char/escoffier.py
+++ b/gi_notifier/data/char/escoffier.py
@@ -17,13 +17,25 @@ class Escoffier(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Secret Source Airflow Accumulator", f"https://genshin-impact.fandom.com/wiki/{quote("Secret_Source_Airflow_Accumulator")}"),
-            source = Source("Secret Source Automaton: Overseer Device", f"https://genshin-impact.fandom.com/wiki/{quote("Secret_Source_Automaton:_Overseer_Device")}")
+            item=Item(
+                "Secret Source Airflow Accumulator",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Secret_Source_Airflow_Accumulator")}",
+            ),
+            source=Source(
+                "Secret Source Automaton: Overseer Device",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Secret_Source_Automaton:_Overseer_Device")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Eroded Horn", f"https://genshin-impact.fandom.com/wiki/{quote("Eroded_Horn")}"),
-            source = Source("Stone Stele Records", f"https://genshin-impact.fandom.com/wiki/{quote("Stone_Stele_Records")}")
+            item=Item(
+                "Eroded Horn",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Eroded_Horn")}",
+            ),
+            source=Source(
+                "Stone Stele Records",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Stone_Stele_Records")}",
+            ),
         )

--- a/gi_notifier/data/char/eula.py
+++ b/gi_notifier/data/char/eula.py
@@ -17,13 +17,25 @@ class Eula(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Crystalline Bloom", f"https://genshin-impact.fandom.com/wiki/{quote("Crystalline_Bloom")}"),
-            source = Source("Cryo Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Hypostasis")}")
+            item=Item(
+                "Crystalline Bloom",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Crystalline_Bloom")}",
+            ),
+            source=Source(
+                "Cryo Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dragon Lord's Crown", f"https://genshin-impact.fandom.com/wiki/{quote("Dragon_Lord's_Crown")}"),
-            source = Source("Beneath the Dragon-Queller", f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}")
+            item=Item(
+                "Dragon Lord's Crown",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dragon_Lord's_Crown")}",
+            ),
+            source=Source(
+                "Beneath the Dragon-Queller",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}",
+            ),
         )

--- a/gi_notifier/data/char/faruzan.py
+++ b/gi_notifier/data/char/faruzan.py
@@ -17,13 +17,25 @@ class Faruzan(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Light Guiding Tetrahedron", f"https://genshin-impact.fandom.com/wiki/{quote("Light_Guiding_Tetrahedron")}"),
-            source = Source("Algorithm of Semi-Intransient Matrix of Overseer Network", f"https://genshin-impact.fandom.com/wiki/{quote("Algorithm_of_Semi-Intransient_Matrix_of_Overseer_Network")}")
+            item=Item(
+                "Light Guiding Tetrahedron",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Light_Guiding_Tetrahedron")}",
+            ),
+            source=Source(
+                "Algorithm of Semi-Intransient Matrix of Overseer Network",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Algorithm_of_Semi-Intransient_Matrix_of_Overseer_Network")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Puppet Strings", f"https://genshin-impact.fandom.com/wiki/{quote("Puppet_Strings")}"),
-            source = Source("Joururi Workshop", f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}")
+            item=Item(
+                "Puppet Strings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Puppet_Strings")}",
+            ),
+            source=Source(
+                "Joururi Workshop",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}",
+            ),
         )

--- a/gi_notifier/data/char/fischl.py
+++ b/gi_notifier/data/char/fischl.py
@@ -17,13 +17,25 @@ class Fischl(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Lightning Prism", f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}"),
-            source = Source("Electro Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}")
+            item=Item(
+                "Lightning Prism",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}",
+            ),
+            source=Source(
+                "Electro Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Spirit Locket of Boreas", f"https://genshin-impact.fandom.com/wiki/{quote("Spirit_Locket_of_Boreas")}"),
-            source = Source("Wolf of the North Challenge", f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}")
+            item=Item(
+                "Spirit Locket of Boreas",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Spirit_Locket_of_Boreas")}",
+            ),
+            source=Source(
+                "Wolf of the North Challenge",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}",
+            ),
         )

--- a/gi_notifier/data/char/freminet.py
+++ b/gi_notifier/data/char/freminet.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+
 from ...models.base import CharacterBase
 from ...models.models import Drop, Item, Source
 from ..book.justice import Justice
@@ -16,13 +17,25 @@ class Freminet(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Artificed Spare Clockwork Component — Coppelius", f"https://genshin-impact.fandom.com/wiki/{quote("Artificed_Spare_Clockwork_Component_—_Coppelius")}"),
-            source = Source("Icewind Suite: Nemesis of Coppelius", f"https://genshin-impact.fandom.com/wiki/{quote("Icewind_Suite:_Nemesis_of_Coppelius")}")
+            item=Item(
+                "Artificed Spare Clockwork Component — Coppelius",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Artificed_Spare_Clockwork_Component_—_Coppelius")}",
+            ),
+            source=Source(
+                "Icewind Suite: Nemesis of Coppelius",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Icewind_Suite:_Nemesis_of_Coppelius")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Worldspan Fern", f"https://genshin-impact.fandom.com/wiki/{quote("Worldspan_Fern")}"),
-            source = Source("The Realm of Beginnings", f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}")
+            item=Item(
+                "Worldspan Fern",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Worldspan_Fern")}",
+            ),
+            source=Source(
+                "The Realm of Beginnings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}",
+            ),
         )

--- a/gi_notifier/data/char/furina.py
+++ b/gi_notifier/data/char/furina.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+
 from ...models.base import CharacterBase
 from ...models.models import Drop, Item, Source
 from ..book.justice import Justice
@@ -16,13 +17,25 @@ class Furina(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Water That Failed To Transcend", f"https://genshin-impact.fandom.com/wiki/{quote("Water_That_Failed_To_Transcend")}"),
-            source = Source("Hydro Tulpa", f"https://genshin-impact.fandom.com/wiki/{quote("Hydro_Tulpa")}")
+            item=Item(
+                "Water That Failed To Transcend",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Water_That_Failed_To_Transcend")}",
+            ),
+            source=Source(
+                "Hydro Tulpa",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hydro_Tulpa")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Lightless Mass", f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Mass")}"),
-            source = Source("All-Devouring Narwhal", f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}")
+            item=Item(
+                "Lightless Mass",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Mass")}",
+            ),
+            source=Source(
+                "All-Devouring Narwhal",
+                f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}",
+            ),
         )

--- a/gi_notifier/data/char/gaming.py
+++ b/gi_notifier/data/char/gaming.py
@@ -17,13 +17,25 @@ class Gaming(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Emperor's Resolution", f"https://genshin-impact.fandom.com/wiki/{quote("Emperor's_Resolution")}"),
-            source = Source("Emperor of Fire and Iron", f"https://genshin-impact.fandom.com/wiki/{quote("Emperor_of_Fire_and_Iron")}")
+            item=Item(
+                "Emperor's Resolution",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Emperor's_Resolution")}",
+            ),
+            source=Source(
+                "Emperor of Fire and Iron",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Emperor_of_Fire_and_Iron")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Lightless Mass", f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Mass")}"),
-            source = Source("All-Devouring Narwhal", f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}")
+            item=Item(
+                "Lightless Mass",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Mass")}",
+            ),
+            source=Source(
+                "All-Devouring Narwhal",
+                f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}",
+            ),
         )

--- a/gi_notifier/data/char/ganyu.py
+++ b/gi_notifier/data/char/ganyu.py
@@ -17,13 +17,25 @@ class Ganyu(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Hoarfrost Core", f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}"),
-            source = Source("Cryo Regisvine", f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}")
+            item=Item(
+                "Hoarfrost Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}",
+            ),
+            source=Source(
+                "Cryo Regisvine",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Shadow of the Warrior", f"https://genshin-impact.fandom.com/wiki/{quote("Shadow_of_the_Warrior")}"),
-            source = Source("Enter the Golden House", f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}")
+            item=Item(
+                "Shadow of the Warrior",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Shadow_of_the_Warrior")}",
+            ),
+            source=Source(
+                "Enter the Golden House",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}",
+            ),
         )

--- a/gi_notifier/data/char/gorou.py
+++ b/gi_notifier/data/char/gorou.py
@@ -17,13 +17,25 @@ class Gorou(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Perpetual Heart", f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Heart")}"),
-            source = Source("Perpetual Mechanical Array", f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Mechanical_Array")}")
+            item=Item(
+                "Perpetual Heart",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Heart")}",
+            ),
+            source=Source(
+                "Perpetual Mechanical Array",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Mechanical_Array")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Molten Moment", f"https://genshin-impact.fandom.com/wiki/{quote("Molten_Moment")}"),
-            source = Source("Narukami Island: Tenshukaku", f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}")
+            item=Item(
+                "Molten Moment",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Molten_Moment")}",
+            ),
+            source=Source(
+                "Narukami Island: Tenshukaku",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}",
+            ),
         )

--- a/gi_notifier/data/char/hu_tao.py
+++ b/gi_notifier/data/char/hu_tao.py
@@ -17,13 +17,25 @@ class HuTao(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Juvenile Jade", f"https://genshin-impact.fandom.com/wiki/{quote("Juvenile_Jade")}"),
-            source = Source("Primo Geovishap", f"https://genshin-impact.fandom.com/wiki/{quote("Primo_Geovishap")}")
+            item=Item(
+                "Juvenile Jade",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Juvenile_Jade")}",
+            ),
+            source=Source(
+                "Primo Geovishap",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Primo_Geovishap")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Shard of a Foul Legacy", f"https://genshin-impact.fandom.com/wiki/{quote("Shard_of_a_Foul_Legacy")}"),
-            source = Source("Enter the Golden House", f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}")
+            item=Item(
+                "Shard of a Foul Legacy",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Shard_of_a_Foul_Legacy")}",
+            ),
+            source=Source(
+                "Enter the Golden House",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}",
+            ),
         )

--- a/gi_notifier/data/char/iansan.py
+++ b/gi_notifier/data/char/iansan.py
@@ -17,13 +17,25 @@ class Iansan(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Ensnaring Gaze", f"https://genshin-impact.fandom.com/wiki/{quote("Ensnaring_Gaze")}"),
-            source = Source("Tenebrous Papilla", f"https://genshin-impact.fandom.com/wiki/{quote("Tenebrous_Papilla")}")
+            item=Item(
+                "Ensnaring Gaze",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ensnaring_Gaze")}",
+            ),
+            source=Source(
+                "Tenebrous Papilla",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tenebrous_Papilla")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Denial and Judgment", f"https://genshin-impact.fandom.com/wiki/{quote("Denial_and_Judgment")}"),
-            source = Source("The Knave", f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}")
+            item=Item(
+                "Denial and Judgment",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Denial_and_Judgment")}",
+            ),
+            source=Source(
+                "The Knave",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}",
+            ),
         )

--- a/gi_notifier/data/char/ifa.py
+++ b/gi_notifier/data/char/ifa.py
@@ -17,13 +17,25 @@ class Ifa(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Sparkless Statue Core", f"https://genshin-impact.fandom.com/wiki/{quote("Sparkless_Statue_Core")}"),
-            source = Source("Lava Dragon Statue", f"https://genshin-impact.fandom.com/wiki/{quote("Lava_Dragon_Statue")}")
+            item=Item(
+                "Sparkless Statue Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Sparkless_Statue_Core")}",
+            ),
+            source=Source(
+                "Lava Dragon Statue",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lava_Dragon_Statue")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Ascended Sample: Rook", f"https://genshin-impact.fandom.com/wiki/{quote("Ascended_Sample:_Rook")}"),
-            source = Source("Unresolved Chess Game", f"https://genshin-impact.fandom.com/wiki/{quote("Unresolved_Chess_Game")}")
+            item=Item(
+                "Ascended Sample: Rook",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ascended_Sample:_Rook")}",
+            ),
+            source=Source(
+                "Unresolved Chess Game",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Unresolved_Chess_Game")}",
+            ),
         )

--- a/gi_notifier/data/char/jean.py
+++ b/gi_notifier/data/char/jean.py
@@ -17,13 +17,25 @@ class Jean(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Hurricane Seed", f"https://genshin-impact.fandom.com/wiki/{quote("Hurricane_Seed")}"),
-            source = Source("Anemo Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Anemo_Hypostasis")}")
+            item=Item(
+                "Hurricane Seed",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hurricane_Seed")}",
+            ),
+            source=Source(
+                "Anemo Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Anemo_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dvalin's Plume", f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Plume")}"),
-            source = Source("Confront Stormterror", f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}")
+            item=Item(
+                "Dvalin's Plume",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Plume")}",
+            ),
+            source=Source(
+                "Confront Stormterror",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}",
+            ),
         )

--- a/gi_notifier/data/char/kachina.py
+++ b/gi_notifier/data/char/kachina.py
@@ -17,13 +17,25 @@ class Kachina(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Overripe Flamegranate", f"https://genshin-impact.fandom.com/wiki/{quote("Overripe_Flamegranate")}"),
-            source = Source("Gluttonous Yumkasaur Mountain King", f"https://genshin-impact.fandom.com/wiki/{quote("Gluttonous_Yumkasaur_Mountain_King")}")
+            item=Item(
+                "Overripe Flamegranate",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Overripe_Flamegranate")}",
+            ),
+            source=Source(
+                "Gluttonous Yumkasaur Mountain King",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Gluttonous_Yumkasaur_Mountain_King")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Fading Candle", f"https://genshin-impact.fandom.com/wiki/{quote("Fading_Candle")}"),
-            source = Source("The Knave", f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}")
+            item=Item(
+                "Fading Candle",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Fading_Candle")}",
+            ),
+            source=Source(
+                "The Knave",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}",
+            ),
         )

--- a/gi_notifier/data/char/kaedehara_kazuha.py
+++ b/gi_notifier/data/char/kaedehara_kazuha.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+
 from ...models.base import CharacterBase
 from ...models.models import Drop, Item, Source
 from ..book.diligence import Diligence
@@ -16,13 +17,25 @@ class KaedeharaKazuha(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Marionette Core", f"https://genshin-impact.fandom.com/wiki/{quote("Marionette_Core")}"),
-            source = Source("Maguu Kenki", f"https://genshin-impact.fandom.com/wiki/{quote("Maguu_Kenki")}")
+            item=Item(
+                "Marionette Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Marionette_Core")}",
+            ),
+            source=Source(
+                "Maguu Kenki",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Maguu_Kenki")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Gilded Scale", f"https://genshin-impact.fandom.com/wiki/{quote("Gilded_Scale")}"),
-            source = Source("Beneath the Dragon-Queller", f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}")
+            item=Item(
+                "Gilded Scale",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Gilded_Scale")}",
+            ),
+            source=Source(
+                "Beneath the Dragon-Queller",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}",
+            ),
         )

--- a/gi_notifier/data/char/kaeya.py
+++ b/gi_notifier/data/char/kaeya.py
@@ -17,13 +17,25 @@ class Kaeya(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Hoarfrost Core", f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}"),
-            source = Source("Cryo Regisvine", f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}")
+            item=Item(
+                "Hoarfrost Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}",
+            ),
+            source=Source(
+                "Cryo Regisvine",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Spirit Locket of Boreas", f"https://genshin-impact.fandom.com/wiki/{quote("Spirit_Locket_of_Boreas")}"),
-            source = Source("Wolf of the North Challenge", f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}")
+            item=Item(
+                "Spirit Locket of Boreas",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Spirit_Locket_of_Boreas")}",
+            ),
+            source=Source(
+                "Wolf of the North Challenge",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}",
+            ),
         )

--- a/gi_notifier/data/char/kamisato_ayaka.py
+++ b/gi_notifier/data/char/kamisato_ayaka.py
@@ -17,13 +17,25 @@ class KamisatoAyaka(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Perpetual Heart", f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Heart")}"),
-            source = Source("Perpetual Mechanical Array", f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Mechanical_Array")}")
+            item=Item(
+                "Perpetual Heart",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Heart")}",
+            ),
+            source=Source(
+                "Perpetual Mechanical Array",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Mechanical_Array")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Bloodjade Branch", f"https://genshin-impact.fandom.com/wiki/{quote("Bloodjade_Branch")}"),
-            source = Source("Beneath the Dragon-Queller", f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}")
+            item=Item(
+                "Bloodjade Branch",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Bloodjade_Branch")}",
+            ),
+            source=Source(
+                "Beneath the Dragon-Queller",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}",
+            ),
         )

--- a/gi_notifier/data/char/kamisato_ayato.py
+++ b/gi_notifier/data/char/kamisato_ayato.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+
 from ...models.base import CharacterBase
 from ...models.models import Drop, Item, Source
 from ..book.elegance import Elegance
@@ -16,13 +17,25 @@ class KamisatoAyato(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Dew of Repudiation", f"https://genshin-impact.fandom.com/wiki/{quote("Dew_of_Repudiation")}"),
-            source = Source("Hydro Hypostases", f"https://genshin-impact.fandom.com/wiki/{quote("Hydro_Hypostases")}")
+            item=Item(
+                "Dew of Repudiation",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dew_of_Repudiation")}",
+            ),
+            source=Source(
+                "Hydro Hypostases",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hydro_Hypostases")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Mudra of the Malefic General", f"https://genshin-impact.fandom.com/wiki/{quote("Mudra_of_the_Malefic_General")}"),
-            source = Source("End of the Oneiric Euthymia", f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}")
+            item=Item(
+                "Mudra of the Malefic General",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Mudra_of_the_Malefic_General")}",
+            ),
+            source=Source(
+                "End of the Oneiric Euthymia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}",
+            ),
         )

--- a/gi_notifier/data/char/kaveh.py
+++ b/gi_notifier/data/char/kaveh.py
@@ -17,13 +17,25 @@ class Kaveh(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Quelled Creeper", f"https://genshin-impact.fandom.com/wiki/{quote("Quelled_Creeper")}"),
-            source = Source("Dendro Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Dendro_Hypostasis")}")
+            item=Item(
+                "Quelled Creeper",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Quelled_Creeper")}",
+            ),
+            source=Source(
+                "Dendro Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dendro_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Primordial Greenbloom", f"https://genshin-impact.fandom.com/wiki/{quote("Primordial_Greenbloom")}"),
-            source = Source("The Realm of Beginnings", f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}")
+            item=Item(
+                "Primordial Greenbloom",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Primordial_Greenbloom")}",
+            ),
+            source=Source(
+                "The Realm of Beginnings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}",
+            ),
         )

--- a/gi_notifier/data/char/keqing.py
+++ b/gi_notifier/data/char/keqing.py
@@ -17,13 +17,25 @@ class Keqing(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Lightning Prism", f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}"),
-            source = Source("Electro Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}")
+            item=Item(
+                "Lightning Prism",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}",
+            ),
+            source=Source(
+                "Electro Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Ring of Boreas", f"https://genshin-impact.fandom.com/wiki/{quote("Ring_of_Boreas")}"),
-            source = Source("Wolf of the North Challenge", f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}")
+            item=Item(
+                "Ring of Boreas",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ring_of_Boreas")}",
+            ),
+            source=Source(
+                "Wolf of the North Challenge",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}",
+            ),
         )

--- a/gi_notifier/data/char/kinich.py
+++ b/gi_notifier/data/char/kinich.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+
 from ...models.base import CharacterBase
 from ...models.models import Drop, Item, Source
 from ..book.kindling import Kindling
@@ -16,13 +17,25 @@ class Kinich(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Lightning Prism", f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}"),
-            source = Source("Electro Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}")
+            item=Item(
+                "Lightning Prism",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}",
+            ),
+            source=Source(
+                "Electro Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Denial and Judgment", f"https://genshin-impact.fandom.com/wiki/{quote("Denial_and_Judgment")}"),
-            source = Source("The Knave", f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}")
+            item=Item(
+                "Denial and Judgment",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Denial_and_Judgment")}",
+            ),
+            source=Source(
+                "The Knave",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}",
+            ),
         )

--- a/gi_notifier/data/char/kirara.py
+++ b/gi_notifier/data/char/kirara.py
@@ -17,13 +17,25 @@ class Kirara(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Evergloom Ring", f"https://genshin-impact.fandom.com/wiki/{quote("Evergloom_Ring")}"),
-            source = Source("Iniquitous Baptist", f"https://genshin-impact.fandom.com/wiki/{quote("Iniquitous_Baptist")}")
+            item=Item(
+                "Evergloom Ring",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Evergloom_Ring")}",
+            ),
+            source=Source(
+                "Iniquitous Baptist",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Iniquitous_Baptist")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Everamber", f"https://genshin-impact.fandom.com/wiki/{quote("Everamber")}"),
-            source = Source("The Realm of Beginnings", f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}")
+            item=Item(
+                "Everamber",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Everamber")}",
+            ),
+            source=Source(
+                "The Realm of Beginnings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}",
+            ),
         )

--- a/gi_notifier/data/char/klee.py
+++ b/gi_notifier/data/char/klee.py
@@ -17,13 +17,25 @@ class Klee(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Everflame Seed", f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}"),
-            source = Source("Pyro Regisvines", f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvines")}")
+            item=Item(
+                "Everflame Seed",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}",
+            ),
+            source=Source(
+                "Pyro Regisvines",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvines")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Ring of Boreas", f"https://genshin-impact.fandom.com/wiki/{quote("Ring_of_Boreas")}"),
-            source = Source("Wolf of the North Challenge", f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}")
+            item=Item(
+                "Ring of Boreas",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ring_of_Boreas")}",
+            ),
+            source=Source(
+                "Wolf of the North Challenge",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}",
+            ),
         )

--- a/gi_notifier/data/char/kujou_sara.py
+++ b/gi_notifier/data/char/kujou_sara.py
@@ -17,13 +17,25 @@ class KujouSara(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Storm Beads", f"https://genshin-impact.fandom.com/wiki/{quote("Storm_Beads")}"),
-            source = Source("Thunder Manifestation", f"https://genshin-impact.fandom.com/wiki/{quote("Thunder_Manifestation")}")
+            item=Item(
+                "Storm Beads",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Storm_Beads")}",
+            ),
+            source=Source(
+                "Thunder Manifestation",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Thunder_Manifestation")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Ashen Heart", f"https://genshin-impact.fandom.com/wiki/{quote("Ashen_Heart")}"),
-            source = Source("Narukami Island: Tenshukaku", f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}")
+            item=Item(
+                "Ashen Heart",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ashen_Heart")}",
+            ),
+            source=Source(
+                "Narukami Island: Tenshukaku",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}",
+            ),
         )

--- a/gi_notifier/data/char/kuki_shinobu.py
+++ b/gi_notifier/data/char/kuki_shinobu.py
@@ -17,13 +17,25 @@ class KukiShinobu(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Runic Fang", f"https://genshin-impact.fandom.com/wiki/{quote("Runic_Fang")}"),
-            source = Source("Ruin Serpent", f"https://genshin-impact.fandom.com/wiki/{quote("Ruin_Serpent")}")
+            item=Item(
+                "Runic Fang",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Runic_Fang")}",
+            ),
+            source=Source(
+                "Ruin Serpent",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ruin_Serpent")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Tears of the Calamitous God", f"https://genshin-impact.fandom.com/wiki/{quote("Tears_of_the_Calamitous_God")}"),
-            source = Source("End of the Oneiric Euthymia", f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}")
+            item=Item(
+                "Tears of the Calamitous God",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tears_of_the_Calamitous_God")}",
+            ),
+            source=Source(
+                "End of the Oneiric Euthymia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}",
+            ),
         )

--- a/gi_notifier/data/char/lan_yan.py
+++ b/gi_notifier/data/char/lan_yan.py
@@ -17,13 +17,25 @@ class LanYan(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Gold-Inscribed Secret Source Core", f"https://genshin-impact.fandom.com/wiki/{quote("Gold-Inscribed_Secret_Source_Core")}"),
-            source = Source("Secret Source Automaton: Configuration Device", f"https://genshin-impact.fandom.com/wiki/{quote("Secret_Source_Automaton:_Configuration_Device")}")
+            item=Item(
+                "Gold-Inscribed Secret Source Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Gold-Inscribed_Secret_Source_Core")}",
+            ),
+            source=Source(
+                "Secret Source Automaton: Configuration Device",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Secret_Source_Automaton:_Configuration_Device")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Eroded Sunfire", f"https://genshin-impact.fandom.com/wiki/{quote("Eroded_Sunfire")}"),
-            source = Source("Stone Stele Records", f"https://genshin-impact.fandom.com/wiki/{quote("Stone_Stele_Records")}")
+            item=Item(
+                "Eroded Sunfire",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Eroded_Sunfire")}",
+            ),
+            source=Source(
+                "Stone Stele Records",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Stone_Stele_Records")}",
+            ),
         )

--- a/gi_notifier/data/char/layla.py
+++ b/gi_notifier/data/char/layla.py
@@ -17,13 +17,25 @@ class Layla(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Perpetual Caliber", f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Caliber")}"),
-            source = Source("Aeonblight Drake: Configuration Device", f"https://genshin-impact.fandom.com/wiki/{quote("Aeonblight_Drake")}")
+            item=Item(
+                "Perpetual Caliber",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Caliber")}",
+            ),
+            source=Source(
+                "Aeonblight Drake: Configuration Device",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Aeonblight_Drake")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Mirror of Mushin", f"https://genshin-impact.fandom.com/wiki/{quote("Mirror_of_Mushin")}"),
-            source = Source("Joururi Workshop", f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}")
+            item=Item(
+                "Mirror of Mushin",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Mirror_of_Mushin")}",
+            ),
+            source=Source(
+                "Joururi Workshop",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}",
+            ),
         )

--- a/gi_notifier/data/char/lisa.py
+++ b/gi_notifier/data/char/lisa.py
@@ -17,13 +17,25 @@ class Lisa(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Lightning Prism", f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}"),
-            source = Source("Electro Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}")
+            item=Item(
+                "Lightning Prism",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}",
+            ),
+            source=Source(
+                "Electro Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dvalin's Claw", f"http://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Claw")}"),
-            source = Source("Confront Stormterror", f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}")
+            item=Item(
+                "Dvalin's Claw",
+                f"http://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Claw")}",
+            ),
+            source=Source(
+                "Confront Stormterror",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}",
+            ),
         )

--- a/gi_notifier/data/char/lynette.py
+++ b/gi_notifier/data/char/lynette.py
@@ -17,13 +17,25 @@ class Lynette(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Artificed Spare Clockwork Component — Coppelia", f"https://genshin-impact.fandom.com/wiki/{quote("Artificed_Spare_Clockwork_Component_—_Coppelia")}"),
-            source = Source("Icewind Suite: Dirge of Coppelia", f"https://genshin-impact.fandom.com/wiki/{quote("Icewind_Suite:_Dirge_of_Coppelia")}")
+            item=Item(
+                "Artificed Spare Clockwork Component — Coppelia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Artificed_Spare_Clockwork_Component_—_Coppelia")}",
+            ),
+            source=Source(
+                "Icewind Suite: Dirge of Coppelia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Icewind_Suite:_Dirge_of_Coppelia")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Everamber", f"https://genshin-impact.fandom.com/wiki/{quote("Everamber")}"),
-            source = Source("The Realm of Beginnings", f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}")
+            item=Item(
+                "Everamber",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Everamber")}",
+            ),
+            source=Source(
+                "The Realm of Beginnings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}",
+            ),
         )

--- a/gi_notifier/data/char/lyney.py
+++ b/gi_notifier/data/char/lyney.py
@@ -17,13 +17,25 @@ class Lyney(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Emperor's Resolution", f"https://genshin-impact.fandom.com/wiki/{quote("Emperor's_Resolution")}"),
-            source = Source("Emperor of Fire and Iron", f"https://genshin-impact.fandom.com/wiki/{quote("Emperor_of_Fire_and_Iron")}")
+            item=Item(
+                "Emperor's Resolution",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Emperor's_Resolution")}",
+            ),
+            source=Source(
+                "Emperor of Fire and Iron",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Emperor_of_Fire_and_Iron")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Primordial Greenbloom", f"https://genshin-impact.fandom.com/wiki/{quote("Primordial_Greenbloom")}"),
-            source = Source("The Realm of Beginnings", f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}")
+            item=Item(
+                "Primordial Greenbloom",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Primordial_Greenbloom")}",
+            ),
+            source=Source(
+                "The Realm of Beginnings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}",
+            ),
         )

--- a/gi_notifier/data/char/mavuika.py
+++ b/gi_notifier/data/char/mavuika.py
@@ -17,13 +17,25 @@ class Mavuika(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Gold-Inscribed Secret Source Core", f"https://genshin-impact.fandom.com/wiki/{quote("Gold-Inscribed_Secret_Source_Core")}"),
-            source = Source("Secret Source Automaton: Configuration Device", f"https://genshin-impact.fandom.com/wiki/{quote("Secret_Source_Automaton:_Configuration_Device")}")
+            item=Item(
+                "Gold-Inscribed Secret Source Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Gold-Inscribed_Secret_Source_Core")}",
+            ),
+            source=Source(
+                "Secret Source Automaton: Configuration Device",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Secret_Source_Automaton:_Configuration_Device")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Eroded Horn", f"https://genshin-impact.fandom.com/wiki/{quote("Eroded_Horn")}"),
-            source = Source("Stone Stele Records", f"https://genshin-impact.fandom.com/wiki/{quote("Stone_Stele_Records")}")
+            item=Item(
+                "Eroded Horn",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Eroded_Horn")}",
+            ),
+            source=Source(
+                "Stone Stele Records",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Stone_Stele_Records")}",
+            ),
         )

--- a/gi_notifier/data/char/mika.py
+++ b/gi_notifier/data/char/mika.py
@@ -17,13 +17,25 @@ class Mika(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Pseudo-Stamens", f"https://genshin-impact.fandom.com/wiki/{quote("Pseudo-Stamens")}"),
-            source = Source("Setekh Wenut", f"https://genshin-impact.fandom.com/wiki/{quote("Setekh_Wenut")}")
+            item=Item(
+                "Pseudo-Stamens",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Pseudo-Stamens")}",
+            ),
+            source=Source(
+                "Setekh Wenut",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Setekh_Wenut")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Mirror of Mushin", f"https://genshin-impact.fandom.com/wiki/{quote("Mirror_of_Mushin")}"),
-            source = Source("Joururi Workshop", f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}")
+            item=Item(
+                "Mirror of Mushin",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Mirror_of_Mushin")}",
+            ),
+            source=Source(
+                "Joururi Workshop",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}",
+            ),
         )

--- a/gi_notifier/data/char/mona.py
+++ b/gi_notifier/data/char/mona.py
@@ -17,13 +17,25 @@ class Mona(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Cleansing Heart", f"https://genshin-impact.fandom.com/wiki/{quote("Cleansing_Heart")}"),
-            source = Source("Rhodeia of Loch", f"https://genshin-impact.fandom.com/wiki/{quote("Rhodeia_of_Loch")}")
+            item=Item(
+                "Cleansing Heart",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cleansing_Heart")}",
+            ),
+            source=Source(
+                "Rhodeia of Loch",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Rhodeia_of_Loch")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Ring of Boreas", f"https://genshin-impact.fandom.com/wiki/{quote("Ring_of_Boreas")}"),
-            source = Source("Wolf of the North Challenge", f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}")
+            item=Item(
+                "Ring of Boreas",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ring_of_Boreas")}",
+            ),
+            source=Source(
+                "Wolf of the North Challenge",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}",
+            ),
         )

--- a/gi_notifier/data/char/mualani.py
+++ b/gi_notifier/data/char/mualani.py
@@ -17,13 +17,25 @@ class Mualani(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Mark of the Binding Blessing", f"https://genshin-impact.fandom.com/wiki/{quote("Mark_of_the_Binding_Blessing")}"),
-            source = Source("Goldflame Qucusaur Tyrant", f"https://genshin-impact.fandom.com/wiki/{quote("Goldflame_Qucusaur_Tyrant")}")
+            item=Item(
+                "Mark of the Binding Blessing",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Mark_of_the_Binding_Blessing")}",
+            ),
+            source=Source(
+                "Goldflame Qucusaur Tyrant",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Goldflame_Qucusaur_Tyrant")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Lightless Mass", f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Mass")}"),
-            source = Source("All-Devouring Narwhal", f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}")
+            item=Item(
+                "Lightless Mass",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Mass")}",
+            ),
+            source=Source(
+                "All-Devouring Narwhal",
+                f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}",
+            ),
         )

--- a/gi_notifier/data/char/nahida.py
+++ b/gi_notifier/data/char/nahida.py
@@ -17,13 +17,25 @@ class Nahida(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Quelled Creeper", f"https://genshin-impact.fandom.com/wiki/{quote("Quelled_Creeper")}"),
-            source = Source("Dendro Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Dendro_Hypostasis")}")
+            item=Item(
+                "Quelled Creeper",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Quelled_Creeper")}",
+            ),
+            source=Source(
+                "Dendro Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dendro_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Puppet Strings", f"https://genshin-impact.fandom.com/wiki/{quote("Puppet_Strings")}"),
-            source = Source("Joururi Workshop", f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}")
+            item=Item(
+                "Puppet Strings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Puppet_Strings")}",
+            ),
+            source=Source(
+                "Joururi Workshop",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}",
+            ),
         )

--- a/gi_notifier/data/char/navia.py
+++ b/gi_notifier/data/char/navia.py
@@ -17,13 +17,25 @@ class Navia(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Artificed Spare Clockwork Component — Coppelius", f"https://genshin-impact.fandom.com/wiki/{quote("Artificed_Spare_Clockwork_Component_—_Coppelius")}"),
-            source = Source("Icewind Suite: Nemesis of Coppelius", f"https://genshin-impact.fandom.com/wiki/{quote("Icewind_Suite:_Nemesis_of_Coppelius")}")
+            item=Item(
+                "Artificed Spare Clockwork Component — Coppelius",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Artificed_Spare_Clockwork_Component_—_Coppelius")}",
+            ),
+            source=Source(
+                "Icewind Suite: Nemesis of Coppelius",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Icewind_Suite:_Nemesis_of_Coppelius")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Lightless Silk String", f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Silk_String")}"),
-            source = Source("All-Devouring Narwhal", f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}")
+            item=Item(
+                "Lightless Silk String",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Silk_String")}",
+            ),
+            source=Source(
+                "All-Devouring Narwhal",
+                f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}",
+            ),
         )

--- a/gi_notifier/data/char/neuvillette.py
+++ b/gi_notifier/data/char/neuvillette.py
@@ -17,13 +17,25 @@ class Neuvillette(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Fontemer Unihorn", f"https://genshin-impact.fandom.com/wiki/{quote("Fontemer_Unihorn")}"),
-            source = Source("Millennial Pearl Seahorse", f"https://genshin-impact.fandom.com/wiki/{quote("Millennial_Pearl_Seahorse")}")
+            item=Item(
+                "Fontemer Unihorn",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Fontemer_Unihorn")}",
+            ),
+            source=Source(
+                "Millennial Pearl Seahorse",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Millennial_Pearl_Seahorse")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Everamber", f"https://genshin-impact.fandom.com/wiki/{quote("Everamber")}"),
-            source = Source("The Realm of Beginnings", f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}")
+            item=Item(
+                "Everamber",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Everamber")}",
+            ),
+            source=Source(
+                "The Realm of Beginnings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}",
+            ),
         )

--- a/gi_notifier/data/char/nilou.py
+++ b/gi_notifier/data/char/nilou.py
@@ -17,13 +17,25 @@ class Nilou(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Perpetual Caliber", f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Caliber")}"),
-            source = Source("Aeonblight Drake: Configuration Device", f"https://genshin-impact.fandom.com/wiki/{quote("Aeonblight_Drake")}")
+            item=Item(
+                "Perpetual Caliber",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Caliber")}",
+            ),
+            source=Source(
+                "Aeonblight Drake: Configuration Device",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Aeonblight_Drake")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Tears of the Calamitous God", f"https://genshin-impact.fandom.com/wiki/{quote("Tears_of_the_Calamitous_God")}"),
-            source = Source("End of the Oneiric Euthymia", f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}")
+            item=Item(
+                "Tears of the Calamitous God",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tears_of_the_Calamitous_God")}",
+            ),
+            source=Source(
+                "End of the Oneiric Euthymia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}",
+            ),
         )

--- a/gi_notifier/data/char/ningguang.py
+++ b/gi_notifier/data/char/ningguang.py
@@ -17,13 +17,25 @@ class Ningguang(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Basalt Pillar", f"https://genshin-impact.fandom.com/wiki/{quote("Basalt_Pillar")}"),
-            source = Source("Geo Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Geo_Hypostasis")}")
+            item=Item(
+                "Basalt Pillar",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Basalt_Pillar")}",
+            ),
+            source=Source(
+                "Geo Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Geo_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Spirit Locket of Boreas", f"https://genshin-impact.fandom.com/wiki/{quote("Spirit_Locket_of_Boreas")}"),
-            source = Source("Wolf of the North Challenge", f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}")
+            item=Item(
+                "Spirit Locket of Boreas",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Spirit_Locket_of_Boreas")}",
+            ),
+            source=Source(
+                "Wolf of the North Challenge",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Wolf_of_the_North_Challenge")}",
+            ),
         )

--- a/gi_notifier/data/char/noelle.py
+++ b/gi_notifier/data/char/noelle.py
@@ -17,13 +17,25 @@ class Noelle(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Basalt Pillar", f"https://genshin-impact.fandom.com/wiki/{quote("Basalt_Pillar")}"),
-            source = Source("Geo Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Geo_Hypostasis")}")
+            item=Item(
+                "Basalt Pillar",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Basalt_Pillar")}",
+            ),
+            source=Source(
+                "Geo Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Geo_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dvalin's Claw", f"http://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Claw")}"),
-            source = Source("Confront Stormterror", f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}")
+            item=Item(
+                "Dvalin's Claw",
+                f"http://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Claw")}",
+            ),
+            source=Source(
+                "Confront Stormterror",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}",
+            ),
         )

--- a/gi_notifier/data/char/ororon.py
+++ b/gi_notifier/data/char/ororon.py
@@ -17,13 +17,25 @@ class Ororon(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Mark of the Binding Blessing", f"https://genshin-impact.fandom.com/wiki/{quote("Mark_of_the_Binding_Blessing")}"),
-            source = Source("Goldflame Qucusaur Tyrant", f"https://genshin-impact.fandom.com/wiki/{quote("Goldflame_Qucusaur_Tyrant")}")
+            item=Item(
+                "Mark of the Binding Blessing",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Mark_of_the_Binding_Blessing")}",
+            ),
+            source=Source(
+                "Goldflame Qucusaur Tyrant",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Goldflame_Qucusaur_Tyrant")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Lightless Silk String", f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Silk_String")}"),
-            source = Source("All-Devouring Narwhal", f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}")
+            item=Item(
+                "Lightless Silk String",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Silk_String")}",
+            ),
+            source=Source(
+                "All-Devouring Narwhal",
+                f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}",
+            ),
         )

--- a/gi_notifier/data/char/qiqi.py
+++ b/gi_notifier/data/char/qiqi.py
@@ -17,13 +17,24 @@ class Qiqi(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Hoarfrost Core", f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}"),
-            source = Source("Cryo Regisvine", f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}")
+            item=Item(
+                "Hoarfrost Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}",
+            ),
+            source=Source(
+                "Cryo Regisvine",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Tail of Boreas", f"https://genshin-impact.fandom.com/wiki/{quote("Tail_of_Boreas")}"),
-            source = Source("Andrius", f"https://genshin-impact.fandom.com/wiki/{quote("Andrius")}")
+            item=Item(
+                "Tail of Boreas",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tail_of_Boreas")}",
+            ),
+            source=Source(
+                "Andrius", f"https://genshin-impact.fandom.com/wiki/{quote("Andrius")}"
+            ),
         )

--- a/gi_notifier/data/char/raiden_shogun.py
+++ b/gi_notifier/data/char/raiden_shogun.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+
 from ...models.base import CharacterBase
 from ...models.models import Drop, Item, Source
 from ..book.light import Light
@@ -16,13 +17,25 @@ class RaidenShogun(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Storm Beads", f"https://genshin-impact.fandom.com/wiki/{quote("Storm_Beads")}"),
-            source = Source("Thunder Manifestation", f"https://genshin-impact.fandom.com/wiki/{quote("Thunder_Manifestation")}")
+            item=Item(
+                "Storm Beads",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Storm_Beads")}",
+            ),
+            source=Source(
+                "Thunder Manifestation",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Thunder_Manifestation")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Molten Moment", f"https://genshin-impact.fandom.com/wiki/{quote("Molten_Moment")}"),
-            source = Source("Narukami Island: Tenshukaku", f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}")
+            item=Item(
+                "Molten Moment",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Molten_Moment")}",
+            ),
+            source=Source(
+                "Narukami Island: Tenshukaku",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}",
+            ),
         )

--- a/gi_notifier/data/char/razor.py
+++ b/gi_notifier/data/char/razor.py
@@ -17,13 +17,25 @@ class Razor(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Lightning Prism", f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}"),
-            source = Source("Electro Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}")
+            item=Item(
+                "Lightning Prism",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightning_Prism")}",
+            ),
+            source=Source(
+                "Electro Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Electro_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dvalin's Claw", f"http://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Claw")}"),
-            source = Source("Confront Stormterror", f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}")
+            item=Item(
+                "Dvalin's Claw",
+                f"http://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Claw")}",
+            ),
+            source=Source(
+                "Confront Stormterror",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}",
+            ),
         )

--- a/gi_notifier/data/char/rosaria.py
+++ b/gi_notifier/data/char/rosaria.py
@@ -17,13 +17,25 @@ class Rosaria(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Hoarfrost Core", f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}"),
-            source = Source("Cryo Regisvine", f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}")
+            item=Item(
+                "Hoarfrost Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hoarfrost_Core")}",
+            ),
+            source=Source(
+                "Cryo Regisvine",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cryo_Regisvine")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Shadow of the Warrior", f"https://genshin-impact.fandom.com/wiki/{quote("Shadow_of_the_Warrior")}"),
-            source = Source("Enter the Golden House", f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}")
+            item=Item(
+                "Shadow of the Warrior",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Shadow_of_the_Warrior")}",
+            ),
+            source=Source(
+                "Enter the Golden House",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}",
+            ),
         )

--- a/gi_notifier/data/char/sangonomiya_kokomi.py
+++ b/gi_notifier/data/char/sangonomiya_kokomi.py
@@ -17,13 +17,25 @@ class SangonomiyaKokomi(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Dew of Repudiation", f"https://genshin-impact.fandom.com/wiki/{quote("Dew_of_Repudiation")}"),
-            source = Source("Hydro Hypostases", f"https://genshin-impact.fandom.com/wiki/{quote("Hydro_Hypostases")}")
+            item=Item(
+                "Dew of Repudiation",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dew_of_Repudiation")}",
+            ),
+            source=Source(
+                "Hydro Hypostases",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hydro_Hypostases")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Hellfire Butterfly", f"https://genshin-impact.fandom.com/wiki/{quote("Hellfire_Butterfly")}"),
-            source = Source("Narukami Island: Tenshukaku", f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}")
+            item=Item(
+                "Hellfire Butterfly",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hellfire_Butterfly")}",
+            ),
+            source=Source(
+                "Narukami Island: Tenshukaku",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}",
+            ),
         )

--- a/gi_notifier/data/char/sayu.py
+++ b/gi_notifier/data/char/sayu.py
@@ -17,13 +17,25 @@ class Sayu(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Marionette Core", f"https://genshin-impact.fandom.com/wiki/{quote("Marionette_Core")}"),
-            source = Source("Maguu Kenki", f"https://genshin-impact.fandom.com/wiki/{quote("Maguu_Kenki")}")
+            item=Item(
+                "Marionette Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Marionette_Core")}",
+            ),
+            source=Source(
+                "Maguu Kenki",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Maguu_Kenki")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Gilded Scale", f"https://genshin-impact.fandom.com/wiki/{quote("Gilded_Scale")}"),
-            source = Source("Beneath the Dragon-Queller", f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}")
+            item=Item(
+                "Gilded Scale",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Gilded_Scale")}",
+            ),
+            source=Source(
+                "Beneath the Dragon-Queller",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}",
+            ),
         )

--- a/gi_notifier/data/char/sethos.py
+++ b/gi_notifier/data/char/sethos.py
@@ -17,13 +17,25 @@ class Sethos(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Cloudseam Scale", f"https://genshin-impact.fandom.com/wiki/{quote("Cloudseam_Scale")}"),
-            source = Source("Solitary Suanni", f"https://genshin-impact.fandom.com/wiki/{quote("Solitary_Suanni")}")
+            item=Item(
+                "Cloudseam Scale",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cloudseam_Scale")}",
+            ),
+            source=Source(
+                "Solitary Suanni",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Solitary_Suanni")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Daka's Bell", f"https://genshin-impact.fandom.com/wiki/{quote("Daka's_Bell")}"),
-            source = Source("Joururi Workshop", f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}")
+            item=Item(
+                "Daka's Bell",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Daka's_Bell")}",
+            ),
+            source=Source(
+                "Joururi Workshop",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}",
+            ),
         )

--- a/gi_notifier/data/char/shenhe.py
+++ b/gi_notifier/data/char/shenhe.py
@@ -17,13 +17,25 @@ class Shenhe(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Dragonheir's False Fin", f"https://genshin-impact.fandom.com/wiki/{quote("Dragonheir's_False_Fin")}"),
-            source = Source("Coral Defenders", f"https://genshin-impact.fandom.com/wiki/{quote("Coral_Defenders")}")
+            item=Item(
+                "Dragonheir's False Fin",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dragonheir's_False_Fin")}",
+            ),
+            source=Source(
+                "Coral Defenders",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Coral_Defenders")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Hellfire Butterfly", f"https://genshin-impact.fandom.com/wiki/{quote("Hellfire_Butterfly")}"),
-            source = Source("Narukami Island: Tenshukaku", f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}")
+            item=Item(
+                "Hellfire Butterfly",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hellfire_Butterfly")}",
+            ),
+            source=Source(
+                "Narukami Island: Tenshukaku",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}",
+            ),
         )

--- a/gi_notifier/data/char/shikanoin_heizou.py
+++ b/gi_notifier/data/char/shikanoin_heizou.py
@@ -17,13 +17,25 @@ class ShikanoinHeizou(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Runic Fang", f"https://genshin-impact.fandom.com/wiki/{quote("Runic_Fang")}"),
-            source = Source("Ruin Serpent", f"https://genshin-impact.fandom.com/wiki/{quote("Ruin_Serpent")}")
+            item=Item(
+                "Runic Fang",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Runic_Fang")}",
+            ),
+            source=Source(
+                "Ruin Serpent",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ruin_Serpent")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("The Meaning of Aeons", f"https://genshin-impact.fandom.com/wiki/{quote("The_Meaning_of_Aeons")}"),
-            source = Source("End of the Oneiric Euthymia", f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}")
+            item=Item(
+                "The Meaning of Aeons",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Meaning_of_Aeons")}",
+            ),
+            source=Source(
+                "End of the Oneiric Euthymia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}",
+            ),
         )

--- a/gi_notifier/data/char/sigewinne.py
+++ b/gi_notifier/data/char/sigewinne.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+
 from ...models.base import CharacterBase
 from ...models.models import Drop, Item, Source
 from ..book.equity import Equity
@@ -16,13 +17,25 @@ class Sigewinne(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Water That Failed To Transcend", f"https://genshin-impact.fandom.com/wiki/{quote("Water_That_Failed_To_Transcend")}"),
-            source = Source("Hydro Tulpa", f"https://genshin-impact.fandom.com/wiki/{quote("Hydro_Tulpa")}")
+            item=Item(
+                "Water That Failed To Transcend",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Water_That_Failed_To_Transcend")}",
+            ),
+            source=Source(
+                "Hydro Tulpa",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hydro_Tulpa")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Lightless Eye of the Maelstrom", f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Eye_of_the_Maelstrom")}"),
-            source = Source("All-Devouring Narwhal", f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}")
+            item=Item(
+                "Lightless Eye of the Maelstrom",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Eye_of_the_Maelstrom")}",
+            ),
+            source=Source(
+                "All-Devouring Narwhal",
+                f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}",
+            ),
         )

--- a/gi_notifier/data/char/skirk.py
+++ b/gi_notifier/data/char/skirk.py
@@ -17,13 +17,25 @@ class Skirk(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Ensnaring Gaze", f"https://genshin-impact.fandom.com/wiki/{quote("Ensnaring_Gaze")}"),
-            source = Source("Tenebrous Papilla", f"https://genshin-impact.fandom.com/wiki/{quote("Tenebrous_Papilla")}")
+            item=Item(
+                "Ensnaring Gaze",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ensnaring_Gaze")}",
+            ),
+            source=Source(
+                "Tenebrous Papilla",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tenebrous_Papilla")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Ascended Sample: Knight", f"https://genshin-impact.fandom.com/wiki/{quote("Ascended_Sample:_Knight")}"),
-            source = Source("Unresolved Chess Game", f"https://genshin-impact.fandom.com/wiki/{quote("Unresolved_Chess_Game")}")
+            item=Item(
+                "Ascended Sample: Knight",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ascended_Sample:_Knight")}",
+            ),
+            source=Source(
+                "Unresolved Chess Game",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Unresolved_Chess_Game")}",
+            ),
         )

--- a/gi_notifier/data/char/sucrose.py
+++ b/gi_notifier/data/char/sucrose.py
@@ -17,13 +17,24 @@ class Sucrose(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Hurricane Seed", f"https://genshin-impact.fandom.com/wiki/{quote("Hurricane_Seed")}"),
-            source = Source("Anemo Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Anemo_Hypostasis")}")
+            item=Item(
+                "Hurricane Seed",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hurricane_Seed")}",
+            ),
+            source=Source(
+                "Anemo Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Anemo_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Spirit Locket of Boreas", f"https://genshin-impact.fandom.com/wiki/{quote("Spirit_Locket_of_Boreas")}"),
-            source = Source("Andrius", f"https://genshin-impact.fandom.com/wiki/{quote("Andrius")}")
+            item=Item(
+                "Spirit Locket of Boreas",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Spirit_Locket_of_Boreas")}",
+            ),
+            source=Source(
+                "Andrius", f"https://genshin-impact.fandom.com/wiki/{quote("Andrius")}"
+            ),
         )

--- a/gi_notifier/data/char/tartaglia.py
+++ b/gi_notifier/data/char/tartaglia.py
@@ -17,13 +17,25 @@ class Tartaglia(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Cleansing Heart", f"https://genshin-impact.fandom.com/wiki/{quote("Cleansing_Heart")}"),
-            source = Source("Rhodeia of Loch", f"https://genshin-impact.fandom.com/wiki/{quote("Rhodeia_of_Loch")}")
+            item=Item(
+                "Cleansing Heart",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cleansing_Heart")}",
+            ),
+            source=Source(
+                "Rhodeia of Loch",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Rhodeia_of_Loch")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Shard of a Foul Legacy", f"https://genshin-impact.fandom.com/wiki/{quote("Shard_of_a_Foul_Legacy")}"),
-            source = Source("Enter the Golden House", f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}")
+            item=Item(
+                "Shard of a Foul Legacy",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Shard_of_a_Foul_Legacy")}",
+            ),
+            source=Source(
+                "Enter the Golden House",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}",
+            ),
         )

--- a/gi_notifier/data/char/thoma.py
+++ b/gi_notifier/data/char/thoma.py
@@ -17,13 +17,25 @@ class Thoma(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Smoldering Pearl", f"https://genshin-impact.fandom.com/wiki/{quote("Smoldering_Pearl")}"),
-            source = Source("Pyro Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Hypostasis")}")
+            item=Item(
+                "Smoldering Pearl",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Smoldering_Pearl")}",
+            ),
+            source=Source(
+                "Pyro Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Hellfire Butterfly", f"https://genshin-impact.fandom.com/wiki/{quote("Hellfire_Butterfly")}"),
-            source = Source("Narukami Island: Tenshukaku", f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}")
+            item=Item(
+                "Hellfire Butterfly",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hellfire_Butterfly")}",
+            ),
+            source=Source(
+                "Narukami Island: Tenshukaku",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}",
+            ),
         )

--- a/gi_notifier/data/char/tighnari.py
+++ b/gi_notifier/data/char/tighnari.py
@@ -17,13 +17,25 @@ class Tighnari(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Majestic Hooked Beak", f"https://genshin-impact.fandom.com/wiki/{quote("Majestic_Hooked_Beak")}"),
-            source = Source("Jadeplume Terrorshroom", f"https://genshin-impact.fandom.com/wiki/{quote("Jadeplume_Terrorshroom")}")
+            item=Item(
+                "Majestic Hooked Beak",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Majestic_Hooked_Beak")}",
+            ),
+            source=Source(
+                "Jadeplume Terrorshroom",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Jadeplume_Terrorshroom")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("The Meaning of Aeons", f"https://genshin-impact.fandom.com/wiki/{quote("The_Meaning_of_Aeons")}"),
-            source = Source("End of the Oneiric Euthymia", f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}")
+            item=Item(
+                "The Meaning of Aeons",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Meaning_of_Aeons")}",
+            ),
+            source=Source(
+                "End of the Oneiric Euthymia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}",
+            ),
         )

--- a/gi_notifier/data/char/varesa.py
+++ b/gi_notifier/data/char/varesa.py
@@ -17,13 +17,25 @@ class Varesa(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Sparkless Statue Core", f"https://genshin-impact.fandom.com/wiki/{quote("Sparkless_Statue_Core")}"),
-            source = Source("Lava Dragon Statue", f"https://genshin-impact.fandom.com/wiki/{quote("Lava_Dragon_Statue")}")
+            item=Item(
+                "Sparkless Statue Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Sparkless_Statue_Core")}",
+            ),
+            source=Source(
+                "Lava Dragon Statue",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lava_Dragon_Statue")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Eroded Scale-Feather", f"https://genshin-impact.fandom.com/wiki/{quote("Eroded_Scale-Feather")}"),
-            source = Source("Lord of Eroded Primal Fire", f"https://genshin-impact.fandom.com/wiki/{quote("Lord_of_Eroded_Primal_Fire")}")
+            item=Item(
+                "Eroded Scale-Feather",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Eroded_Scale-Feather")}",
+            ),
+            source=Source(
+                "Lord of Eroded Primal Fire",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lord_of_Eroded_Primal_Fire")}",
+            ),
         )

--- a/gi_notifier/data/char/venti.py
+++ b/gi_notifier/data/char/venti.py
@@ -17,13 +17,24 @@ class Venti(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Hurricane Seed", f"https://genshin-impact.fandom.com/wiki/{quote("Hurricane_Seed")}"),
-            source = Source("Anemo Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Anemo_Hypostasis")}")
+            item=Item(
+                "Hurricane Seed",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Hurricane_Seed")}",
+            ),
+            source=Source(
+                "Anemo Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Anemo_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Tail of Boreas", f"https://genshin-impact.fandom.com/wiki/{quote("Tail_of_Boreas")}"),
-            source = Source("Andrius", f"https://genshin-impact.fandom.com/wiki/{quote("Andrius")}")
+            item=Item(
+                "Tail of Boreas",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tail_of_Boreas")}",
+            ),
+            source=Source(
+                "Andrius", f"https://genshin-impact.fandom.com/wiki/{quote("Andrius")}"
+            ),
         )

--- a/gi_notifier/data/char/wanderer.py
+++ b/gi_notifier/data/char/wanderer.py
@@ -17,13 +17,25 @@ class Wanderer(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Perpetual Caliber", f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Caliber")}"),
-            source = Source("Aeonblight Drake", f"https://genshin-impact.fandom.com/wiki/{quote("Aeonblight_Drake")}")
+            item=Item(
+                "Perpetual Caliber",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Perpetual_Caliber")}",
+            ),
+            source=Source(
+                "Aeonblight Drake",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Aeonblight_Drake")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Daka's Bell", f"https://genshin-impact.fandom.com/wiki/{quote("Daka's_Bell")}"),
-            source = Source("Joururi Workshop", f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}")
+            item=Item(
+                "Daka's Bell",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Daka's_Bell")}",
+            ),
+            source=Source(
+                "Joururi Workshop",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}",
+            ),
         )

--- a/gi_notifier/data/char/wriothesley.py
+++ b/gi_notifier/data/char/wriothesley.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+
 from ...models.base import CharacterBase
 from ...models.models import Drop, Item, Source
 from ..book.order import Order
@@ -16,13 +17,25 @@ class Wriothesley(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Tourbillon Device", f"https://genshin-impact.fandom.com/wiki/{quote("\"Tourbillon_Device\"")}"),
-            source = Source("Prototype Cal. Breguet", f"https://genshin-impact.fandom.com/wiki/{quote("Prototype_Cal._Breguet")}")
+            item=Item(
+                "Tourbillon Device",
+                f"https://genshin-impact.fandom.com/wiki/{quote("\"Tourbillon_Device\"")}",
+            ),
+            source=Source(
+                "Prototype Cal. Breguet",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Prototype_Cal._Breguet")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Primordial Greenbloom", f"https://genshin-impact.fandom.com/wiki/{quote("Primordial_Greenbloom")}"),
-            source = Source("The Realm of Beginnings", f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}")
+            item=Item(
+                "Primordial Greenbloom",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Primordial_Greenbloom")}",
+            ),
+            source=Source(
+                "The Realm of Beginnings",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Realm_of_Beginnings")}",
+            ),
         )

--- a/gi_notifier/data/char/xiangling.py
+++ b/gi_notifier/data/char/xiangling.py
@@ -17,13 +17,25 @@ class Xiangling(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Everflame Seed", f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}"),
-            source = Source("Pyro Regisvine", f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvine")}")
+            item=Item(
+                "Everflame Seed",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}",
+            ),
+            source=Source(
+                "Pyro Regisvine",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvine")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dvalin's Claw", f"http://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Claw")}"),
-            source = Source("Confront Stormterror", f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}")
+            item=Item(
+                "Dvalin's Claw",
+                f"http://genshin-impact.fandom.com/wiki/{quote("Dvalin's_Claw")}",
+            ),
+            source=Source(
+                "Confront Stormterror",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Confront_Stormterror")}",
+            ),
         )

--- a/gi_notifier/data/char/xianyun.py
+++ b/gi_notifier/data/char/xianyun.py
@@ -17,13 +17,25 @@ class Xianyun(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Cloudseam Scale", f"https://genshin-impact.fandom.com/wiki/{quote("Cloudseam_Scale")}"),
-            source = Source("Solitary Suanni", f"https://genshin-impact.fandom.com/wiki/{quote("Solitary_Suanni")}")
+            item=Item(
+                "Cloudseam Scale",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cloudseam_Scale")}",
+            ),
+            source=Source(
+                "Solitary Suanni",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Solitary_Suanni")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Lightless Eye of the Maelstrom", f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Eye_of_the_Maelstrom")}"),
-            source = Source("All-Devouring Narwhal", f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}")
+            item=Item(
+                "Lightless Eye of the Maelstrom",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Lightless_Eye_of_the_Maelstrom")}",
+            ),
+            source=Source(
+                "All-Devouring Narwhal",
+                f"https://genshin-impact.fandom.com/wiki/{quote("All-Devouring_Narwhal")}",
+            ),
         )

--- a/gi_notifier/data/char/xiao.py
+++ b/gi_notifier/data/char/xiao.py
@@ -17,13 +17,25 @@ class Xiao(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Juvenile Jade", f"https://genshin-impact.fandom.com/wiki/{quote("Juvenile_Jade")}"),
-            source = Source("Primo Geovishap", f"https://genshin-impact.fandom.com/wiki/{quote("Primo_Geovishap")}")
+            item=Item(
+                "Juvenile Jade",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Juvenile_Jade")}",
+            ),
+            source=Source(
+                "Primo Geovishap",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Primo_Geovishap")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Shadow of the Warrior", f"https://genshin-impact.fandom.com/wiki/{quote("Shadow_of_the_Warrior")}"),
-            source = Source("Enter the Golden House", f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}")
+            item=Item(
+                "Shadow of the Warrior",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Shadow_of_the_Warrior")}",
+            ),
+            source=Source(
+                "Enter the Golden House",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}",
+            ),
         )

--- a/gi_notifier/data/char/xilonen.py
+++ b/gi_notifier/data/char/xilonen.py
@@ -17,13 +17,25 @@ class Xilonen(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Gold-Inscribed Secret Source Core", f"https://genshin-impact.fandom.com/wiki/{quote("Gold-Inscribed_Secret_Source_Core")}"),
-            source = Source("Secret Source Automaton: Configuration Device", f"https://genshin-impact.fandom.com/wiki/{quote("Secret_Source_Automaton:_Configuration_Device")}")
+            item=Item(
+                "Gold-Inscribed Secret Source Core",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Gold-Inscribed_Secret_Source_Core")}",
+            ),
+            source=Source(
+                "Secret Source Automaton: Configuration Device",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Secret_Source_Automaton:_Configuration_Device")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Mirror of Mushin", f"https://genshin-impact.fandom.com/wiki/{quote("Mirror_of_Mushin")}"),
-            source = Source("Joururi Workshop", f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}")
+            item=Item(
+                "Mirror of Mushin",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Mirror_of_Mushin")}",
+            ),
+            source=Source(
+                "Joururi Workshop",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}",
+            ),
         )

--- a/gi_notifier/data/char/xingqiu.py
+++ b/gi_notifier/data/char/xingqiu.py
@@ -17,13 +17,24 @@ class Xingqiu(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Cleansing Heart", f"https://genshin-impact.fandom.com/wiki/{quote("Cleansing_Heart")}"),
-            source = Source("Rhodeia of Loch", f"https://genshin-impact.fandom.com/wiki/{quote("Rhodeia_of_Loch")}")
+            item=Item(
+                "Cleansing Heart",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Cleansing_Heart")}",
+            ),
+            source=Source(
+                "Rhodeia of Loch",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Rhodeia_of_Loch")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Tail of Boreas", f"https://genshin-impact.fandom.com/wiki/{quote("Tail_of_Boreas")}"),
-            source = Source("Andrius", f"https://genshin-impact.fandom.com/wiki/{quote("Andrius")}")
+            item=Item(
+                "Tail of Boreas",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tail_of_Boreas")}",
+            ),
+            source=Source(
+                "Andrius", f"https://genshin-impact.fandom.com/wiki/{quote("Andrius")}"
+            ),
         )

--- a/gi_notifier/data/char/xinyan.py
+++ b/gi_notifier/data/char/xinyan.py
@@ -17,13 +17,25 @@ class Xinyan(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Everflame Seed", f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}"),
-            source = Source("Pyro Regisvine", f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvine")}")
+            item=Item(
+                "Everflame Seed",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Everflame_Seed")}",
+            ),
+            source=Source(
+                "Pyro Regisvine",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Regisvine")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Tusk of Monoceros Caeli", f"https://genshin-impact.fandom.com/wiki/{quote("Tusk_of_Monoceros_Caeli")}"),
-            source = Source("Enter the Golden House", f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}")
+            item=Item(
+                "Tusk of Monoceros Caeli",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tusk_of_Monoceros_Caeli")}",
+            ),
+            source=Source(
+                "Enter the Golden House",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}",
+            ),
         )

--- a/gi_notifier/data/char/yae_miko.py
+++ b/gi_notifier/data/char/yae_miko.py
@@ -17,13 +17,25 @@ class YaeMiko(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Dragonheir's False Fin", f"https://genshin-impact.fandom.com/wiki/{quote("Dragonheir's_False_Fin")}"),
-            source = Source("Coral Defenders", f"https://genshin-impact.fandom.com/wiki/{quote("Coral_Defenders")}")
+            item=Item(
+                "Dragonheir's False Fin",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dragonheir's_False_Fin")}",
+            ),
+            source=Source(
+                "Coral Defenders",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Coral_Defenders")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("The Meaning of Aeons", f"https://genshin-impact.fandom.com/wiki/{quote("The_Meaning_of_Aeons")}"),
-            source = Source("End of the Oneiric Euthymia", f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}")
+            item=Item(
+                "The Meaning of Aeons",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Meaning_of_Aeons")}",
+            ),
+            source=Source(
+                "End of the Oneiric Euthymia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("End_of_the_Oneiric_Euthymia")}",
+            ),
         )

--- a/gi_notifier/data/char/yanfei.py
+++ b/gi_notifier/data/char/yanfei.py
@@ -17,13 +17,25 @@ class Yanfei(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Juvenile Jade", f"https://genshin-impact.fandom.com/wiki/{quote("Juvenile_Jade")}"),
-            source = Source("Primo Geovishap", f"https://genshin-impact.fandom.com/wiki/{quote("Primo_Geovishap")}")
+            item=Item(
+                "Juvenile Jade",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Juvenile_Jade")}",
+            ),
+            source=Source(
+                "Primo Geovishap",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Primo_Geovishap")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Bloodjade Branch", f"https://genshin-impact.fandom.com/wiki/{quote("Bloodjade_Branch")}"),
-            source = Source("Beneath the Dragon-Queller", f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}")
+            item=Item(
+                "Bloodjade Branch",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Bloodjade_Branch")}",
+            ),
+            source=Source(
+                "Beneath the Dragon-Queller",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}",
+            ),
         )

--- a/gi_notifier/data/char/yaoyao.py
+++ b/gi_notifier/data/char/yaoyao.py
@@ -17,13 +17,25 @@ class Yaoyao(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Quelled Creeper", f"https://genshin-impact.fandom.com/wiki/{quote("Quelled_Creeper")}"),
-            source = Source("Dendro Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Dendro_Hypostasis")}")
+            item=Item(
+                "Quelled Creeper",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Quelled_Creeper")}",
+            ),
+            source=Source(
+                "Dendro Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dendro_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Daka's Bell", f"https://genshin-impact.fandom.com/wiki/{quote("Daka's_Bell")}"),
-            source = Source("Joururi Workshop", f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}")
+            item=Item(
+                "Daka's Bell",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Daka's_Bell")}",
+            ),
+            source=Source(
+                "Joururi Workshop",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Joururi_Workshop")}",
+            ),
         )

--- a/gi_notifier/data/char/yelan.py
+++ b/gi_notifier/data/char/yelan.py
@@ -17,13 +17,25 @@ class Yelan(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Runic Fang", f"https://genshin-impact.fandom.com/wiki/{quote("Runic_Fang")}"),
-            source = Source("Ruin Serpent", f"https://genshin-impact.fandom.com/wiki/{quote("Ruin_Serpent")}")
+            item=Item(
+                "Runic Fang",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Runic_Fang")}",
+            ),
+            source=Source(
+                "Ruin Serpent",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ruin_Serpent")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Gilded Scale", f"https://genshin-impact.fandom.com/wiki/{quote("Gilded_Scale")}"),
-            source = Source("Beneath the Dragon-Queller", f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}")
+            item=Item(
+                "Gilded Scale",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Gilded_Scale")}",
+            ),
+            source=Source(
+                "Beneath the Dragon-Queller",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}",
+            ),
         )

--- a/gi_notifier/data/char/yoimiya.py
+++ b/gi_notifier/data/char/yoimiya.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+
 from ...models.base import CharacterBase
 from ...models.models import Drop, Item, Source
 from ..book.transience import Transience
@@ -16,13 +17,25 @@ class Yoimiya(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Smoldering Pearl", f"https://genshin-impact.fandom.com/wiki/{quote("Smoldering_Pearl")}"),
-            source = Source("Pyro Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Hypostasis")}")
+            item=Item(
+                "Smoldering Pearl",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Smoldering_Pearl")}",
+            ),
+            source=Source(
+                "Pyro Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Pyro_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Dragon Lord's Crown", f"https://genshin-impact.fandom.com/wiki/{quote("Dragon_Lord's_Crown")}"),
-            source = Source("Beneath the Dragon-Queller", f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}")
+            item=Item(
+                "Dragon Lord's Crown",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Dragon_Lord's_Crown")}",
+            ),
+            source=Source(
+                "Beneath the Dragon-Queller",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Beneath_the_Dragon-Queller")}",
+            ),
         )

--- a/gi_notifier/data/char/yumemizuki_mizuki.py
+++ b/gi_notifier/data/char/yumemizuki_mizuki.py
@@ -17,13 +17,25 @@ class YumemizukiMizuki(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Talisman of the Enigmatic Land", f"https://genshin-impact.fandom.com/wiki/{quote("Talisman_of_the_Enigmatic_Land")}"),
-            source = Source("Wayward Hermetic Spiritspeaker", f"https://genshin-impact.fandom.com/wiki/{quote("Wayward_Hermetic_Spiritspeaker")}")
+            item=Item(
+                "Talisman of the Enigmatic Land",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Talisman_of_the_Enigmatic_Land")}",
+            ),
+            source=Source(
+                "Wayward Hermetic Spiritspeaker",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Wayward_Hermetic_Spiritspeaker")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Fading Candle", f"https://genshin-impact.fandom.com/wiki/{quote("Fading_Candle")}"),
-            source = Source("The Knave", f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}")
+            item=Item(
+                "Fading Candle",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Fading_Candle")}",
+            ),
+            source=Source(
+                "The Knave",
+                f"https://genshin-impact.fandom.com/wiki/{quote("The_Knave")}",
+            ),
         )

--- a/gi_notifier/data/char/yun_jin.py
+++ b/gi_notifier/data/char/yun_jin.py
@@ -17,13 +17,25 @@ class YunJin(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Riftborn Regalia", f"https://genshin-impact.fandom.com/wiki/{quote("Riftborn_Regalia")}"),
-            source = Source("Golden Wolflord", f"https://genshin-impact.fandom.com/wiki/{quote("Golden_Wolflord")}")
+            item=Item(
+                "Riftborn Regalia",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Riftborn_Regalia")}",
+            ),
+            source=Source(
+                "Golden Wolflord",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Golden_Wolflord")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Ashen Heart", f"https://genshin-impact.fandom.com/wiki/{quote("Ashen_Heart")}"),
-            source = Source("Narukami Island: Tenshukaku", f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}")
+            item=Item(
+                "Ashen Heart",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Ashen_Heart")}",
+            ),
+            source=Source(
+                "Narukami Island: Tenshukaku",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Narukami_Island:_Tenshukaku")}",
+            ),
         )

--- a/gi_notifier/data/char/zhongli.py
+++ b/gi_notifier/data/char/zhongli.py
@@ -17,13 +17,25 @@ class Zhongli(CharacterBase):
     @property
     def normal_boss_drop(self):
         return Drop(
-            item = Item("Basalt Pillar", f"https://genshin-impact.fandom.com/wiki/{quote("Basalt_Pillar")}"),
-            source = Source("Geo Hypostasis", f"https://genshin-impact.fandom.com/wiki/{quote("Geo_Hypostasis")}")
+            item=Item(
+                "Basalt Pillar",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Basalt_Pillar")}",
+            ),
+            source=Source(
+                "Geo Hypostasis",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Geo_Hypostasis")}",
+            ),
         )
 
     @property
     def weekly_boss_drop(self):
         return Drop(
-            item = Item("Tusk of Monoceros Caeli", f"https://genshin-impact.fandom.com/wiki/{quote("Tusk_of_Monoceros_Caeli")}"),
-            source = Source("Enter the Golden House", f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}")
+            item=Item(
+                "Tusk of Monoceros Caeli",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Tusk_of_Monoceros_Caeli")}",
+            ),
+            source=Source(
+                "Enter the Golden House",
+                f"https://genshin-impact.fandom.com/wiki/{quote("Enter_the_Golden_House")}",
+            ),
         )

--- a/gi_notifier/file.py
+++ b/gi_notifier/file.py
@@ -9,8 +9,9 @@ def load_data():
             return json.load(f)
     return {}
 
+
 def save_data(data):
     if not config.DATA_FILE.exists():
-         config.DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+        config.DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
     with open(config.DATA_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=4)

--- a/gi_notifier/handler/chat_handler.py
+++ b/gi_notifier/handler/chat_handler.py
@@ -31,10 +31,13 @@ async def addition(update: Update, context: ContextTypes.DEFAULT_TYPE):
             save_data(data)
 
         await context.bot.send_message(
-            chat_id=chat_member.chat.id,
-            text="Hello! I'm now part of this group."
+            chat_id=chat_member.chat.id, text="Hello! I'm now part of this group."
         )
-        config.logger.debug(f"Bot added to chat: {chat_member.chat.title}, id:{chat_member.chat.id}")  #noqa: E501
+        config.logger.debug(
+            f"Bot added to chat: {chat_member.chat.title}, id:{chat_member.chat.id}"
+        )
 
     elif chat_member.new_chat_member.status == "left":
-        config.logger.debug(f"Bot removed from chat: {chat_member.chat.title}, id:{chat_member.chat.id}")  #noqa: E501
+        config.logger.debug(
+            f"Bot removed from chat: {chat_member.chat.title}, id:{chat_member.chat.id}"
+        )

--- a/gi_notifier/handler/command_handler.py
+++ b/gi_notifier/handler/command_handler.py
@@ -16,27 +16,30 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     data = load_data()
 
     if user_id not in data:
-        data[user_id] = {
-            "user_id": user.id,
-            "chat_bot_id": None,
-            "group_bot_id": []
-        }
+        data[user_id] = {"user_id": user.id, "chat_bot_id": None, "group_bot_id": []}
 
     if chat.type == "private":
         data[user_id]["chat_bot_id"] = chat_id
     else:
         if chat_id not in data[user_id]["group_bot_id"]:
             data[user_id]["group_bot_id"].append(chat_id)
-        
+
     save_data(data)
 
     username = user.username or user.full_name
-    await update.message.reply_text(f"Hello, {username}! Welcome to the Genshin Impact Notifier Bot.")  #noqa: E501
-    config.logger.debug(f"User {username} started bot in chat: {chat.title}, id:{chat_id}")
+    await update.message.reply_text(
+        f"Hello, {username}! Welcome to the Genshin Impact Notifier Bot."
+    )
+    config.logger.debug(
+        f"User {username} started bot in chat: {chat.title}, id:{chat_id}"
+    )
+
 
 async def resinday(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not context.args:
-        await update.effective_message.reply_text("Please specify a character name, e.g. /resin Amber")  #noqa: E501
+        await update.effective_message.reply_text(
+            "Please specify a character name, e.g. /resin Amber"
+        )
 
     name = " ".join(context.args).title()
     try:
@@ -46,4 +49,6 @@ async def resinday(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         await update.effective_message.reply_text(resin_plan, parse_mode="HTML")
     except Exception:
-        await update.effective_message.reply_text(f"No such character '{name}' is available. Feel free to try some other character.")  #noqa: E501
+        await update.effective_message.reply_text(
+            f"No such character '{name}' is available. Feel free to try some other character."
+        )

--- a/gi_notifier/main.py
+++ b/gi_notifier/main.py
@@ -1,23 +1,24 @@
 from asyncio import run
+from pathlib import Path as pathtype
 
 from click import Path, command, option
 
 from . import config, runner
-from pathlib import Path as pathtype
 
 
 @command()
-@option("--bottoken",
-        required=True,
-        help="Telegram Bot token")
-@option("--timezone",
-        required=False,
-        default=config.TIMEZONE,
-        help="Timezone of the place for running the telegram bot")
-@option("--database",
-        required=False,
-        type=Path(dir_okay=False),
-        help="Path to the user data JSON file"
+@option("--bottoken", required=True, help="Telegram Bot token")
+@option(
+    "--timezone",
+    required=False,
+    default=config.TIMEZONE,
+    help="Timezone of the place for running the telegram bot",
+)
+@option(
+    "--database",
+    required=False,
+    type=Path(dir_okay=False),
+    help="Path to the user data JSON file",
 )
 def main(bottoken: str, timezone: str, database: Path):
     config.BOTTOKEN = bottoken

--- a/gi_notifier/models/base.py
+++ b/gi_notifier/models/base.py
@@ -7,29 +7,23 @@ from .models import ConstantResource, Drop, MaterialGroup, Weekday
 class MaterialGroupBase(ABC):
     @property
     @abstractmethod
-    def drop(self) -> Drop:
-        ...
+    def drop(self) -> Drop: ...
 
     @property
     @abstractmethod
-    def available_on(self) -> list[Weekday]:
-        ...
+    def available_on(self) -> list[Weekday]: ...
 
     def is_available_today(self, today: Weekday) -> bool:
         return today in self.available_on
 
     def as_material_group(self) -> MaterialGroup:
-        return MaterialGroup(
-            drop=self.drop,
-            available_on=self.available_on
-        )
+        return MaterialGroup(drop=self.drop, available_on=self.available_on)
 
 
 class CharacterBase(ABC):
     @property
     @abstractmethod
-    def name(self) -> str:
-        ...
+    def name(self) -> str: ...
 
     @cached_property
     def constant_resource(self) -> ConstantResource:
@@ -37,18 +31,15 @@ class CharacterBase(ABC):
 
     @property
     @abstractmethod
-    def talent_book(self) -> MaterialGroup:
-        ...
+    def talent_book(self) -> MaterialGroup: ...
 
     @property
     @abstractmethod
-    def normal_boss_drop(self) -> Drop:
-        ...
+    def normal_boss_drop(self) -> Drop: ...
 
     @property
     @abstractmethod
-    def weekly_boss_drop(self) -> Drop:
-        ...
+    def weekly_boss_drop(self) -> Drop: ...
 
     def is_talent_book_available_today(self, today: Weekday) -> bool:
         return today in self.talent_book.available_on

--- a/gi_notifier/models/models.py
+++ b/gi_notifier/models/models.py
@@ -6,6 +6,7 @@ class Weekday(Enum):
     """
     Class for having the days of the week.
     """
+
     MON = "Monday"
     TUE = "Tuesday"
     WED = "Wednesday"
@@ -20,6 +21,7 @@ class Item:
     """
     Data class for ontainable items.
     """
+
     name: str = ""
     link: str = ""
 
@@ -29,6 +31,7 @@ class Source:
     """
     Data class for the source of the obtainable item.
     """
+
     name: str = ""
     link: str = ""
 
@@ -38,13 +41,12 @@ class Drop:
     """
     Data class for the generating the message for an obtainable item.
     """
+
     item: Item
-    source: Source = field(default_factory = Source)
+    source: Source = field(default_factory=Source)
 
     def to_use(self) -> str:
-        return (
-            f"""Use your <a href="{self.item.link}">{self.item.name}</a> for"""
-        )
+        return f"""Use your <a href="{self.item.link}">{self.item.name}</a> for"""
 
     def to_claim(self) -> str:
         return (
@@ -53,9 +55,7 @@ class Drop:
         )
 
     def to_make(self) -> str:
-        return (
-            f"""Making <a href="{self.item.link}">{self.item.name}</a> for future usage"""
-        )
+        return f"""Making <a href="{self.item.link}">{self.item.name}</a> for future usage"""
 
     def to_obtain(self) -> str:
         return (
@@ -69,20 +69,33 @@ class Resin:
     """
     Data class for resins.
     """
+
     original_resin: Drop = field(
-        default_factory = lambda: Drop(
-            item = Item("Original Resin", "https://genshin-impact.fandom.com/wiki/Original_Resin")
+        default_factory=lambda: Drop(
+            item=Item(
+                "Original Resin",
+                "https://genshin-impact.fandom.com/wiki/Original_Resin",
+            )
         )
     )
     transient_resin: Drop = field(
-        default_factory = lambda: Drop(
-            item = Item("Transient Resin", "https://genshin-impact.fandom.com/wiki/Transient_Resin"),
-            source = Source("Realm Depot", "https://genshin-impact.fandom.com/wiki/Serenitea_Pot/Realm_Depot")
+        default_factory=lambda: Drop(
+            item=Item(
+                "Transient Resin",
+                "https://genshin-impact.fandom.com/wiki/Transient_Resin",
+            ),
+            source=Source(
+                "Realm Depot",
+                "https://genshin-impact.fandom.com/wiki/Serenitea_Pot/Realm_Depot",
+            ),
         )
     )
     condensed_resin: Drop = field(
-        default_factory = lambda: Drop(
-            item = Item("Condensed Resin", "https://genshin-impact.fandom.com/wiki/Condensed_Resin")
+        default_factory=lambda: Drop(
+            item=Item(
+                "Condensed Resin",
+                "https://genshin-impact.fandom.com/wiki/Condensed_Resin",
+            )
         )
     )
 
@@ -92,19 +105,28 @@ class ConstantResource:
     """
     Dataclass for the constant resource.
     """
+
     experience: Drop = field(
-        default_factory = lambda: Drop(
-            item = Item("Experience", "https://genshin-impact.fandom.com/wiki/Experience"),
-            source = Source("Ley Line Outcrop - Blossom of Revelation", "https://genshin-impact.fandom.com/wiki/Ley_Line_Outcrop")
+        default_factory=lambda: Drop(
+            item=Item(
+                "Experience", "https://genshin-impact.fandom.com/wiki/Experience"
+            ),
+            source=Source(
+                "Ley Line Outcrop - Blossom of Revelation",
+                "https://genshin-impact.fandom.com/wiki/Ley_Line_Outcrop",
+            ),
         )
     )
     mora: Drop = field(
-        default_factory = lambda: Drop(
-            item = Item("Mora", "https://genshin-impact.fandom.com/wiki/Mora"),
-            source = Source("Ley Line Outcrop - Blossom of Wealth", "https://genshin-impact.fandom.com/wiki/Ley_Line_Outcrop")
+        default_factory=lambda: Drop(
+            item=Item("Mora", "https://genshin-impact.fandom.com/wiki/Mora"),
+            source=Source(
+                "Ley Line Outcrop - Blossom of Wealth",
+                "https://genshin-impact.fandom.com/wiki/Ley_Line_Outcrop",
+            ),
         )
     )
-    resin: Resin = field(default_factory = Resin)
+    resin: Resin = field(default_factory=Resin)
 
 
 @dataclass

--- a/gi_notifier/runner.py
+++ b/gi_notifier/runner.py
@@ -6,7 +6,7 @@ from telegram.ext import ApplicationBuilder, ChatMemberHandler, CommandHandler
 
 from . import config
 from .handler.chat_handler import addition
-from .handler.command_handler import start, resinday
+from .handler.command_handler import resinday, start
 from .scheduler import scheduled_task
 
 

--- a/gi_notifier/scheduler/__init__.py
+++ b/gi_notifier/scheduler/__init__.py
@@ -26,14 +26,16 @@ async def scheduled_task():
             if chat_id not in seen:
                 try:
                     await sender.send_message(
-                        chat_id=chat_id,
-                        text=resin_plan,
-                        parse_mode="HTML"
+                        chat_id=chat_id, text=resin_plan, parse_mode="HTML"
                     )
-                    config.logger.debug(f"Scheduled notification sent to chat: {chat_id}")
+                    config.logger.debug(
+                        f"Scheduled notification sent to chat: {chat_id}"
+                    )
                     sent_count += 1
                 except TelegramError as e:
-                    config.logger.warning(f"Failed to send notification to chat: {chat_id}: {e}")
+                    config.logger.warning(
+                        f"Failed to send notification to chat: {chat_id}: {e}"
+                    )
             seen.add(chat_id)
 
     config.logger.debug(f"Scheduled notification sent to {sent_count} chat(s).")

--- a/gi_notifier/temp/__init__.py
+++ b/gi_notifier/temp/__init__.py
@@ -1,5 +1,4 @@
 from ..data.char.emilie import Emilie
 from ..data.char.mavuika import Mavuika
 
-
 characters = [Emilie(), Mavuika()]

--- a/gi_notifier/util.py
+++ b/gi_notifier/util.py
@@ -7,6 +7,7 @@ from .models.models import Resin, Weekday
 def get_today() -> Weekday:
     return Weekday(list(Weekday)[datetime.now().weekday()])
 
+
 def generate_daily_resin_plan(today: Weekday, characters: list[CharacterBase]) -> str:
     message_lines = [f"<b>{today.value}</b>", ""]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,6 @@ fix = true
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "S", "B", "UP"]
 
-[tool.ruff.lint.per-file-ignores]
-"gi_notifier/data/*" = ["E501"]
-
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Hi,

I added the support of `pre-commit` for checking and formatting the codebase. This will help the contributors to add more logical contribution rather than utilising their time checking the linting.

```shell
(venv) sdglitched@sdglitched:~/Projects/gi-notifier$ pre-commit run --all-files
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
black....................................................................Passed
ruff check...............................................................Passed
(venv) sdglitched@sdglitched:~/Projects/gi-notifier$ 
```

Fixes: #13 