### PR TITLE
Add notifications for daily check-in

### DIFF
--- a/gi_notifier/models/models.py
+++ b/gi_notifier/models/models.py
@@ -48,7 +48,7 @@ class Drop:
 
     def to_claim(self) -> str:
         return (
-            f"""Do not forget to claim your <a href="{self.item.link}">{self.item.name}</a> """
+            f"""Claim your <a href="{self.item.link}">{self.item.name}</a> """
             f"""from <a href="{self.source.link}">{self.source.name}</a>"""
         )
 
@@ -105,6 +105,16 @@ class ConstantResource:
         )
     )
     resin: Resin = field(default_factory = Resin)
+
+
+@dataclass
+class DailyCheckin:
+    reward: Drop = field(
+        default_factory = lambda: Drop(
+            item = Item("HoYoLAB Community Daily Check-In", "https://genshin-impact.fandom.com/wiki/HoYoLAB_Community_Daily_Check-In"),
+            source = Source("HoYoLAB", "https://www.hoyolab.com")
+        )
+    )
 
 
 @dataclass

--- a/gi_notifier/util.py
+++ b/gi_notifier/util.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from .models.base import CharacterBase
-from .models.models import Resin, Weekday
+from .models.models import DailyCheckin, Resin, Weekday
 
 
 def get_today() -> Weekday:
@@ -32,5 +32,7 @@ def generate_daily_resin_plan(today: Weekday, characters: list[CharacterBase]) -
 
     if today.value == "Monday":
         message_lines.append(Resin().transient_resin.to_claim())
+    
+    message_lines.append(DailyCheckin().reward.to_claim())
 
     return "\n".join(message_lines)


### PR DESCRIPTION
Hi,

I added support for sending notifications for claiming daily `check-in` while sending the requested/scheduled data.

```
/r amber
```

```
Saturday

For Amber

Use your [Original Resin](https://genshin-impact.fandom.com/wiki/Original_Resin) for
1. Obtaining [Dvalin's Sigh](https://genshin-impact.fandom.com/wiki/Dvalin%27s_Sigh) from [Confront Stormterror](https://genshin-impact.fandom.com/wiki/Confront_Stormterror)
2. Obtaining [Everflame Seed](https://genshin-impact.fandom.com/wiki/Everflame_Seed) from [Pyro Regisvines](https://genshin-impact.fandom.com/wiki/Pyro_Regisvines)
3. Obtaining [Mora](https://genshin-impact.fandom.com/wiki/Mora) from [Ley Line Outcrop - Blossom of Wealth](https://genshin-impact.fandom.com/wiki/Ley_Line_Outcrop)
4. Obtaining [Experience](https://genshin-impact.fandom.com/wiki/Experience) from [Ley Line Outcrop - Blossom of Revelation](https://genshin-impact.fandom.com/wiki/Ley_Line_Outcrop)
5. Making [Condensed Resin](https://genshin-impact.fandom.com/wiki/Condensed_Resin) for future usage

Claim your [HoYoLAB Community Daily Check-In](https://genshin-impact.fandom.com/wiki/HoYoLAB_Community_Daily_Check-In) from [HoYoLAB](https://www.hoyolab.com/)
```

```
Scheduled (with transient resin reminder set for Saturday)
```

```
Saturday

For Emilie

Use your [Original Resin](https://genshin-impact.fandom.com/wiki/Original_Resin) for
1. Obtaining [Order Books](https://genshin-impact.fandom.com/wiki/Order_Book) from [Pale Forgotten Glory](https://genshin-impact.fandom.com/wiki/Pale_Forgotten_Glory)
2. Obtaining [Silken Feather](https://genshin-impact.fandom.com/wiki/Silken_Feather) from [The Knave](https://genshin-impact.fandom.com/wiki/The_Knave)
3. Obtaining [Fragment of a Golden Melody](https://genshin-impact.fandom.com/wiki/Fragment_of_a_Golden_Melody) from [Statue of Marble and Brass](https://genshin-impact.fandom.com/wiki/%22Statue_of_Marble_and_Brass%22)
4. Obtaining [Mora](https://genshin-impact.fandom.com/wiki/Mora) from [Ley Line Outcrop - Blossom of Wealth](https://genshin-impact.fandom.com/wiki/Ley_Line_Outcrop)
5. Obtaining [Experience](https://genshin-impact.fandom.com/wiki/Experience) from [Ley Line Outcrop - Blossom of Revelation](https://genshin-impact.fandom.com/wiki/Ley_Line_Outcrop)
6. Making [Condensed Resin](https://genshin-impact.fandom.com/wiki/Condensed_Resin) for future usage

For Mavuika

Use your [Original Resin](https://genshin-impact.fandom.com/wiki/Original_Resin) for
1. Obtaining [Eroded Horn](https://genshin-impact.fandom.com/wiki/Eroded_Horn) from [Stone Stele Records](https://genshin-impact.fandom.com/wiki/Stone_Stele_Records)
2. Obtaining [Gold-Inscribed Secret Source Core](https://genshin-impact.fandom.com/wiki/Gold-Inscribed_Secret_Source_Core) from [Secret Source Automaton: Configuration Device](https://genshin-impact.fandom.com/wiki/Secret_Source_Automaton%3A_Configuration_Device)
3. Obtaining [Mora](https://genshin-impact.fandom.com/wiki/Mora) from [Ley Line Outcrop - Blossom of Wealth](https://genshin-impact.fandom.com/wiki/Ley_Line_Outcrop)
4. Obtaining [Experience](https://genshin-impact.fandom.com/wiki/Experience) from [Ley Line Outcrop - Blossom of Revelation](https://genshin-impact.fandom.com/wiki/Ley_Line_Outcrop)
5. Making [Condensed Resin](https://genshin-impact.fandom.com/wiki/Condensed_Resin) for future usage

Claim your [Transient Resin](https://genshin-impact.fandom.com/wiki/Transient_Resin) from [Realm Depot](https://genshin-impact.fandom.com/wiki/Serenitea_Pot/Realm_Depot)
Claim your [HoYoLAB Community Daily Check-In](https://genshin-impact.fandom.com/wiki/HoYoLAB_Community_Daily_Check-In) from [HoYoLAB](https://www.hoyolab.com/)
```

Fixes: #6 